### PR TITLE
Fix Notification interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,13 +73,14 @@ func (c *Client) Production() *Client {
 // indicating whether the notification was accepted or rejected by the APNs
 // gateway, or an error if something goes wrong.
 func (c *Client) Push(n *Notification) (*Response, error) {
-	jsonBytes, err := json.Marshal(n.Payload)
+	payload, err := json.Marshal(n)
+
 	if err != nil {
 		return nil, err
 	}
 
 	url := fmt.Sprintf("%v/3/device/%v", c.Host, n.DeviceToken)
-	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonBytes))
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(payload))
 	setHeaders(req, n)
 	httpRes, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -2,7 +2,6 @@ package apns2_test
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -125,11 +124,10 @@ func TestHeaders(t *testing.T) {
 
 func TestPayload(t *testing.T) {
 	n := mockNotification()
-	bytes, _ := json.Marshal(n.Payload)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
 		assert.NoError(t, err)
-		assert.Equal(t, bytes, body)
+		assert.Equal(t, n.Payload, body)
 	}))
 	defer server.Close()
 	_, err := mockClient(server.URL).Push(n)

--- a/notification.go
+++ b/notification.go
@@ -1,6 +1,9 @@
 package apns2
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 const (
 	// PriorityLow will tell APNs to send the push message at a time that takes
@@ -57,4 +60,16 @@ type Notification struct {
 	// Refer to "The Remote Notification Payload" section in the Apple Local and
 	// Remote Notification Programming Guide for more info.
 	Payload interface{}
+}
+
+// PayloadBytes converts the notification payload to JSON.
+func (n *Notification) MarshalJSON() ([]byte, error) {
+	switch n.Payload.(type) {
+	case string:
+		return []byte(n.Payload.(string)), nil
+	case []byte:
+		return n.Payload.([]byte), nil
+	default:
+		return json.Marshal(n.Payload)
+	}
 }

--- a/notification_test.go
+++ b/notification_test.go
@@ -1,0 +1,32 @@
+package apns2_test
+
+import (
+	"testing"
+
+	"github.com/sideshow/apns2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalJSON(t *testing.T) {
+	scenarios := []struct {
+		in  interface{}
+		out []byte
+		err error
+	}{
+		{`{"a": "b"}`, []byte(`{"a": "b"}`), nil},
+		{[]byte(`{"a": "b"}`), []byte(`{"a": "b"}`), nil},
+		{struct {
+			A string `json:"a"`
+		}{"b"}, []byte(`{"a":"b"}`), nil},
+	}
+
+	notification := &apns2.Notification{}
+
+	for _, scenario := range scenarios {
+		notification.Payload = scenario.in
+		payloadBytes, err := notification.MarshalJSON()
+
+		assert.Equal(t, scenario.out, payloadBytes)
+		assert.Equal(t, scenario.err, err)
+	}
+}


### PR DESCRIPTION
We should not try to encode strings or byte arrays. We also shouldn't accept invalid json.