### PR TITLE
Fix Timestamp parsing issue

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -67,15 +67,15 @@ func TestClientBadTransportError(t *testing.T) {
 }
 
 func TestClientNameToCertificate(t *testing.T) {
-	certificate2 := tls.Certificate{}
-	client2 := apns.NewClient(certificate2)
-	name2 := client2.HTTPClient.Transport.(*http2.Transport).TLSClientConfig.NameToCertificate
-	assert.Len(t, name2, 0)
-
 	certificate, _ := certificate.FromP12File("certificate/_fixtures/certificate-valid.p12", "")
 	client := apns.NewClient(certificate)
 	name := client.HTTPClient.Transport.(*http2.Transport).TLSClientConfig.NameToCertificate
 	assert.Len(t, name, 1)
+
+	certificate2 := tls.Certificate{}
+	client2 := apns.NewClient(certificate2)
+	name2 := client2.HTTPClient.Transport.(*http2.Transport).TLSClientConfig.NameToCertificate
+	assert.Len(t, name2, 0)
 }
 
 // Functional Tests
@@ -182,7 +182,7 @@ func Test410UnregisteredResponse(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("apns-id", apnsID)
 		w.WriteHeader(http.StatusGone)
-		w.Write([]byte("{\"reason\":\"Unregistered\", \"timestamp\":\"1421147681\"}"))
+		w.Write([]byte("{\"reason\":\"Unregistered\", \"timestamp\": 1458114061260 }"))
 	}))
 	defer server.Close()
 	res, err := mockClient(server.URL).Push(n)
@@ -190,7 +190,7 @@ func Test410UnregisteredResponse(t *testing.T) {
 	assert.Equal(t, 410, res.StatusCode)
 	assert.Equal(t, apnsID, res.ApnsID)
 	assert.Equal(t, apns.ReasonUnregistered, res.Reason)
-	assert.Equal(t, int64(1421147681), res.Timestamp.Unix())
+	assert.Equal(t, int64(1458114061260)/1000, res.Timestamp.Unix())
 	assert.Equal(t, false, res.Sent())
 }
 

--- a/response.go
+++ b/response.go
@@ -101,13 +101,10 @@ type Time struct {
 }
 
 func (t *Time) UnmarshalJSON(b []byte) error {
-	if b[0] == '"' && b[len(b)-1] == '"' {
-		b = b[1 : len(b)-1]
-	}
-	i, err := strconv.ParseInt(string(b), 10, 64)
+	ts, err := strconv.Atoi(string(b))
 	if err != nil {
 		return err
 	}
-	t.Time = time.Unix(i, 0)
+	t.Time = time.Unix(int64(ts/1000), 0)
 	return nil
 }

--- a/response_test.go
+++ b/response_test.go
@@ -17,18 +17,11 @@ func TestResponseSent(t *testing.T) {
 	assert.Equal(t, false, (&apns.Response{StatusCode: 400}).Sent())
 }
 
-func TestStringTimestampParse(t *testing.T) {
-	response := &apns.Response{}
-	payload := "{\"reason\":\"Unregistered\", \"timestamp\":\"1421147681\"}"
-	json.Unmarshal([]byte(payload), &response)
-	assert.Equal(t, int64(1421147681), response.Timestamp.Unix())
-}
-
 func TestIntTimestampParse(t *testing.T) {
 	response := &apns.Response{}
-	payload := "{\"reason\":\"Unregistered\", \"timestamp\":1421147681}"
+	payload := "{\"reason\":\"Unregistered\", \"timestamp\":1458114061260}"
 	json.Unmarshal([]byte(payload), &response)
-	assert.Equal(t, int64(1421147681), response.Timestamp.Unix())
+	assert.Equal(t, int64(1458114061260)/1000, response.Timestamp.Unix())
 }
 
 func TestInvalidTimestampParse(t *testing.T) {


### PR DESCRIPTION
- Fixes an issue where APNs timestamps were being parsed incorrectly.
- Removes some redundant code and tests.

APNs returns a Unix time with millisecond precision. We were parsing and not
accounting for the milliseconds, which was giving an invalid Time. This has been
tested on APNs production gateway and now parses and returns the correct Time.