### PR TITLE
Fix apns id Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ if err != nil {
   return
 }
 if res.Sent() {
-  log.Println("APNs ID:", res.ApnsID())
+  log.Println("APNs ID:", res.ApnsID)
 }
 ```
 


### PR DESCRIPTION
ApnsID of response structire is string type not function.

Please refer to: https://github.com/sideshow/apns2/blob/master/response.go#L86

cc @sideshow  
