### PR TITLE
Include printing of APNS ID in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ func main() {
     log.Println("Error:", err)
     return
   }
+  
+  log.Println("APNs ID:", res.ApnsID)
 }
 ```
 


### PR DESCRIPTION
It's from the example, and if one was to copy the README verbatim, they'd get the error `res declared and not used`