### PR TITLE
Add AlertLocArgs method.

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -161,6 +161,17 @@ func (p *Payload) AlertLaunchImage(image string) *Payload {
 	return p
 }
 
+// AlertLocArgs sets the aps alert localization args on the payload.
+// These are the variable string values to appear in place of the format
+// specifiers in loc-key. See Localized Formatted Strings in Apple
+// documentation for more information.
+//
+//  {"aps":{"alert":{"loc-args":args}}}
+func (p *Payload) AlertLocArgs(args []string) *Payload {
+	p.aps().alert().LocArgs = args
+	return p
+}
+
 // AlertLocKey sets the aps alert localization key on the payload.
 // This is the key to an alert-message string in the Localizable.strings file
 // for the current localization. See Localized Formatted Strings in Apple

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -76,6 +76,12 @@ func TestAlertTitleLocKey(t *testing.T) {
 	assert.Equal(t, `{"aps":{"alert":{"title-loc-key":"GAME_PLAY_REQUEST_FORMAT"}}}`, string(b))
 }
 
+func TestAlertLocArgs(t *testing.T) {
+	payload := NewPayload().AlertLocArgs([]string{"Jenna", "Frank"})
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":{"loc-args":["Jenna","Frank"]}}}`, string(b))
+}
+
 func TestAlertTitleLocArgs(t *testing.T) {
 	payload := NewPayload().AlertTitleLocArgs([]string{"Jenna", "Frank"})
 	b, _ := json.Marshal(payload)


### PR DESCRIPTION
Missing set `loc-args` property.

ref: https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH107-SW1