### PR TITLE
Remove alert action key.

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -20,7 +20,6 @@ type aps struct {
 }
 
 type alert struct {
-	Action       string   `json:"action,omitempty"`
 	ActionLocKey string   `json:"action-loc-key,omitempty"`
 	Body         string   `json:"body,omitempty"`
 	LaunchImage  string   `json:"launch-image,omitempty"`
@@ -180,17 +179,6 @@ func (p *Payload) AlertLocArgs(args []string) *Payload {
 //	{"aps":{"alert":{"loc-key":key}}}
 func (p *Payload) AlertLocKey(key string) *Payload {
 	p.aps().alert().LocKey = key
-	return p
-}
-
-// AlertAction sets the aps alert action on the payload.
-// This is the label of the action button, if the user sets the notifications
-// to appear as alerts. This label should be succinct, such as “Details” or
-// “Read more”. If omitted, the default value is “Show”.
-//
-//	{"aps":{"alert":{"action":action}}}
-func (p *Payload) AlertAction(action string) *Payload {
-	p.aps().alert().Action = action
 	return p
 }
 

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -106,12 +106,6 @@ func TestAlertLocKey(t *testing.T) {
 	assert.Equal(t, `{"aps":{"alert":{"loc-key":"LOC"}}}`, string(b))
 }
 
-func TestAlertAction(t *testing.T) {
-	payload := NewPayload().AlertAction("action")
-	b, _ := json.Marshal(payload)
-	assert.Equal(t, `{"aps":{"alert":{"action":"action"}}}`, string(b))
-}
-
 func TestAlertActionLocKey(t *testing.T) {
 	payload := NewPayload().AlertActionLocKey("PLAY")
 	b, _ := json.Marshal(payload)


### PR DESCRIPTION
`Action` key is not exist in [alert property](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH107-SW4).