### PR TITLE
add timeouts for transport.dialtls and http.client

### DIFF
--- a/client.go
+++ b/client.go
@@ -47,10 +47,8 @@ func NewClient(certificate tls.Certificate) (*Client, error) {
 		tlsConfig.BuildNameToCertificate()
 	}
 	transport := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
-	if len(timeout) > 0 {
-		transport.TLSHandshakeTimeout = time.Duration(timeout[0]) * time.Second
+		TLSClientConfig:     tlsConfig,
+		TLSHandshakeTimeout: 1 * time.Second,
 	}
 	if err := http2.ConfigureTransport(transport); err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ func NewClient(certificate tls.Certificate, timeout ...int) *Client {
 	}
 	if len(timeout) > 0 {
 		transport.DialTLS = func(network, addr string, cfg *tls.Config) (net.Conn, error) {
-			return tls.DialWithDialer(&net.Dialer{Timeout: timeout[0] * time.Second}, network, addr, cfg)
+			return tls.DialWithDialer(&net.Dialer{Timeout: time.Duration(timeout[0]) * time.Second}, network, addr, cfg)
 		}
 	}
 	return &Client{

--- a/client.go
+++ b/client.go
@@ -56,7 +56,7 @@ func NewClient(certificate tls.Certificate) *Client {
 	return &Client{
 		HTTPClient: &http.Client{
 			Transport: transport,
-			Timeout:   3 * time.Second,
+			Timeout:   5 * time.Second,
 		},
 		Certificate: certificate,
 		Host:        DefaultHost,


### PR DESCRIPTION
Workaround for [#17](https://github.com/sideshow/apns2/issues/17) and [#20](https://github.com/sideshow/apns2/issues/20).

Discussed in detail in [#20](https://github.com/sideshow/apns2/issues/20).