### PR TITLE
Add support for the mutable-content flag 

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -17,6 +17,7 @@ type aps struct {
 	ContentAvailable int         `json:"content-available,omitempty"`
 	URLArgs          []string    `json:"url-args,omitempty"`
 	Sound            string      `json:"sound,omitempty"`
+	MutableContent   int         `json:"mutable-content,omitempty"`
 }
 
 type alert struct {
@@ -93,6 +94,15 @@ func (p *Payload) Sound(sound string) *Payload {
 //	{"aps":{"content-available":1}}
 func (p *Payload) ContentAvailable() *Payload {
 	p.aps().ContentAvailable = 1
+	return p
+}
+
+// MutableContent sets the aps mutable-content on the payload to 1.
+// This will indicate to the to the system to call your Notification Service
+// extension to mutate or replace the notification's content.
+//	{"aps":{"mutable-content":1}}
+func (p *Payload) MutableContent() *Payload {
+	p.aps().MutableContent = 1
 	return p
 }
 

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -50,6 +50,12 @@ func TestContentAvailable(t *testing.T) {
 	assert.Equal(t, `{"aps":{"content-available":1}}`, string(b))
 }
 
+func TestMutableContent(t *testing.T) {
+	payload := NewPayload().MutableContent()
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"mutable-content":1}}`, string(b))
+}
+
 func TestCustom(t *testing.T) {
 	payload := NewPayload().Custom("key", "val")
 	b, _ := json.Marshal(payload)


### PR DESCRIPTION
Add support for the new iOS 10 Notification Services extensions. More details [here](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension).

Fixes #27 