### PR TITLE
Change example to reflect production

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
   notification.Topic = "com.sideshow.Apns2"
   notification.Payload = []byte(`{"aps":{"alert":"Hello!"}}`) // See Payload section below
 
-  client := apns.NewClient(cert).Development()
+  client := apns.NewClient(cert).Production()
   res, err := client.Push(notification)
 
   if err != nil {

--- a/_example/main.go
+++ b/_example/main.go
@@ -24,7 +24,7 @@ func main() {
 		}
 	`)
 
-	client := apns.NewClient(cert).Development()
+	client := apns.NewClient(cert).Production()
 	res, err := client.Push(notification)
 
 	if err != nil {


### PR DESCRIPTION
First off, awesome library!

I added this into my project and everything was working great. But when I went to switch over to production, I just removed the `.Development()` and assumed the default host would be production (my bad... never assume). I think replacing the `Development` with `Production` in the example would clarify this and help future developers from making the same mistake.

