### PR TITLE
Client for GAE Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ func SomeHandler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-***Note:*** You only need to use `GAEClient` if the application is running on GAE "Classic". GAE "Flexbile Environment" can handle the standard `Client`.
+***Notes:*** You only need to use `GAEClient` if the application is running on a production GAE "Classic" instance. GAE development and "flexbile" environments should use the standard `Client`. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,29 @@ Flags:
       --version            Show application version.
 ```
 
+## App Engine
+
+To use APNS/2 inside of Google App Engine, utilize a `GAEClient`. This will channel requests to Apple via the [`google.golang.org/appengine/socket`](google.golang.org/appengine/socket) package under the hood. Learn more the [constraints and restrictions here](https://cloud.google.com/appengine/docs/go/sockets/).
+
+`GAEClient` works exactly like the normal `Client`, but  passing a valid `context.Context` to the client is required before pushing a notification.
+
+```go
+// use NewGAEClient()
+apnsClient = apns.NewGAEClient(cert).Production()
+
+// ...
+
+func SomeHandler(w http.ResponseWriter, r *http.Request) {
+    ctx := appengine.NewContext(r)
+    // Gotta set a valid context.Context
+    apnsClient.SetContext(ctx)
+    res, err = apnsClient.Push(&apns.Notification{})
+    // ...
+}
+```
+
+***Note:*** You only need to use `GAEClient` if the application is running on GAE "Classic". GAE "Flexbile Environment" can handle the standard `Client`.
+
 ## License
 
 The MIT License (MIT)

--- a/appengine.go
+++ b/appengine.go
@@ -24,10 +24,10 @@ type GAEClient struct {
 //  client := NewGAEClient(cert)
 //  client.SetContext(ctx)
 //  client.Push(notification)
-func (gclient *GAEClient) SetContext(ctx context.Context) {
-	gclient.Ctx = ctx
-	if gclient.GConn != nil {
-		gclient.GConn.SetContext(gclient.Ctx)
+func (c *GAEClient) SetContext(ctx context.Context) {
+	c.Ctx = ctx
+	if c.GConn != nil {
+		c.GConn.SetContext(c.Ctx)
 	}
 }
 

--- a/appengine.go
+++ b/appengine.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GAEClient embeds an apns2.Client to use the special socket.Dial() method to connect to Apple
-// Arbitratry net.Conn's are not allowed in the Google App Engine Classic environemtn
+// Arbitratry net.Conn's are not allowed in the Google App Engine Classic environment
 // https://cloud.google.com/appengine/docs/go/sockets
 type GAEClient struct {
 	*Client

--- a/appengine.go
+++ b/appengine.go
@@ -1,0 +1,70 @@
+// +build appengine
+
+package apns2
+
+import (
+	"crypto/tls"
+	"net"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
+	"google.golang.org/appengine/socket"
+)
+
+// GAEClient embeds an apns2.Client to use the special socket.Dial() method to connect to Apple
+// Arbitratry net.Conn's are not allowed in the Google App Engine Classic environemtn
+// https://cloud.google.com/appengine/docs/go/sockets
+type GAEClient struct {
+	*Client
+	GConn *socket.Conn
+	Ctx   context.Context
+}
+
+// SetContext assigns a new context to the underlying socket.Conn
+//  client := NewGAEClient(cert)
+//  client.SetContext(ctx)
+//  client.Push(notification)
+func (gclient *GAEClient) SetContext(ctx context.Context) {
+	gclient.Ctx = ctx
+	if gclient.GConn != nil {
+		gclient.GConn.SetContext(gclient.Ctx)
+	}
+}
+
+// NewGAEClient returns a new GAEClient with an underlying http.Client configured with
+// the correct APNs HTTP/2 transport settings. It does not connect to the APNs
+// until the first Notification is sent via the Push method.
+//
+// As per the Apple APNs Provider API, you should keep a handle on this client
+// so that you can keep your connections with APNs open across multiple
+// notifications; don’t repeatedly open and close connections. APNs treats rapid
+// connection and disconnection as a denial-of-service attack.
+func NewGAEClient(certificate tls.Certificate) *GAEClient {
+	gclient := &GAEClient{Client: NewClient(certificate)}
+
+	transport := gclient.Client.HTTPClient.Transport.(*http2.Transport)
+	transport.DialTLS = func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+		gConn, err := socket.Dial(gclient.Ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		gclient.GConn = gConn
+
+		tlsConn := tls.Client(gConn, cfg)
+		return tlsConn, nil
+	}
+
+	return gclient
+}
+
+// Development sets the Client to use the APNs development push endpoint.
+func (c *GAEClient) Development() *GAEClient {
+	c.Host = HostDevelopment
+	return c
+}
+
+// Production sets the Client to use the APNs production push endpoint.
+func (c *GAEClient) Production() *GAEClient {
+	c.Host = HostProduction
+	return c
+}

--- a/appengine_test.go
+++ b/appengine_test.go
@@ -1,0 +1,72 @@
+// +build appengine
+
+package apns2_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apns "github.com/sideshow/apns2"
+	"github.com/sideshow/apns2/certificate"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/http2"
+	"google.golang.org/appengine/aetest"
+)
+
+// Mocks
+
+func mockGAEClient(url string) *apns.GAEClient {
+	cert, _ := certificate.FromP12File("certificate/_fixtures/certificate-valid.p12", "")
+	gclient := apns.NewGAEClient(cert)
+	gclient.Client.Host = url
+	return gclient
+}
+
+// Unit Tests
+
+func TestGAEClientDefaultHost(t *testing.T) {
+	client := apns.NewGAEClient(mockCert())
+	assert.Equal(t, "https://api.development.push.apple.com", client.Host)
+}
+
+func TestGAEClientDevelopmentHost(t *testing.T) {
+	client := apns.NewGAEClient(mockCert()).Development()
+	assert.Equal(t, "https://api.development.push.apple.com", client.Host)
+}
+
+func TestGAEClientProductionHost(t *testing.T) {
+	client := apns.NewGAEClient(mockCert()).Production()
+	assert.Equal(t, "https://api.push.apple.com", client.Host)
+}
+
+func TestGAEConnection(t *testing.T) {
+	n := mockNotification()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("apns-id", "XXXXXXXXXXXXXXX")
+	}))
+	server.TLS = &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2", "h2-14"},
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	ctx, done, err := aetest.NewContext()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer done()
+
+	gclient := mockGAEClient(server.URL)
+
+	transport := gclient.Client.HTTPClient.Transport.(*http2.Transport)
+	transport.TLSClientConfig.InsecureSkipVerify = true
+	transport.TLSClientConfig.NextProtos = []string{"h2", "h2-14"}
+
+	gclient.SetContext(ctx)
+	_, err = gclient.Push(n)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Hey @sideshow, thanks for this killer APNS package.

This fork adds a distinct client for using the package from within Google App Engine (classic). Annoyingly, an application can't make a general `net.Conn`, it has to use a special [`appengine/socket` package](https://cloud.google.com/appengine/docs/go/sockets/).

I added the `+build appengine` flag so it's only available when used inside the [GAE go-sdk](https://cloud.google.com/appengine/downloads#Google_App_Engine_SDK_for_Go). 

Usage is like this...

``` go
import (
    "net/http"

    apns "github.com/sideshow/apns2"
    "github.com/sideshow/apns2/certificate"
    "google.golang.org/appengine"
)

var apnsClient *apns.GAEClient

func init() {
    // ...

    cert, _ := certificate.FromPemBytes([]byte("..."), "")
    apnsClient = apns.NewGAEClient(cert).Production()

    //...
}

func SomeHandler(w http.ResponseWriter, r *http.Request) {
    // ...

    ctx := appengine.NewContext(r)

    apnsClient.SetContext(ctx) // Gotta set a valid context

    res, err = apnsClient.Push(&apns.Notification{})

    // ...
}
```

Tests:

```
// Use the gae-sdk go wrapper
$ goapp test
```
