### PR TITLE
Add iOS10 thread-id to notification

### DIFF
--- a/client.go
+++ b/client.go
@@ -128,6 +128,9 @@ func setHeaders(r *http.Request, n *Notification) {
 	if n.CollapseID != "" {
 		r.Header.Set("apns-collapse-id", n.CollapseID)
 	}
+	if n.ThreadID != "" {
+		r.Header.Set("thread-id", n.ThreadID)
+	}
 	if n.Priority > 0 {
 		r.Header.Set("apns-priority", fmt.Sprintf("%v", n.Priority))
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -122,6 +122,7 @@ func TestDefaultHeaders(t *testing.T) {
 		assert.Equal(t, "", r.Header.Get("apns-priority"))
 		assert.Equal(t, "", r.Header.Get("apns-topic"))
 		assert.Equal(t, "", r.Header.Get("apns-expiration"))
+		assert.Equal(t, "", r.Header.Get("thread-id"))
 	}))
 	defer server.Close()
 	_, err := mockClient(server.URL).Push(n)
@@ -132,6 +133,7 @@ func TestHeaders(t *testing.T) {
 	n := mockNotification()
 	n.ApnsID = "84DB694F-464F-49BD-960A-D6DB028335C9"
 	n.CollapseID = "game1.start.identifier"
+	n.ThreadID = "game1.thread.1"
 	n.Topic = "com.testapp"
 	n.Priority = 10
 	n.Expiration = time.Now()
@@ -139,6 +141,7 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, n.ApnsID, r.Header.Get("apns-id"))
 		assert.Equal(t, n.CollapseID, r.Header.Get("apns-collapse-id"))
 		assert.Equal(t, "10", r.Header.Get("apns-priority"))
+		assert.Equal(t, n.ThreadID, r.Header.Get("thread-id"))
 		assert.Equal(t, n.Topic, r.Header.Get("apns-topic"))
 		assert.Equal(t, fmt.Sprintf("%v", n.Expiration.Unix()), r.Header.Get("apns-expiration"))
 	}))

--- a/notification.go
+++ b/notification.go
@@ -32,8 +32,9 @@ type Notification struct {
 	// response.
 	ApnsID string
 
-	// A string which allows a notification to be replaced by a new notification
-	// with the same CollapseID.
+	// A string which allows multiple notifications with the same collapse identifier
+	// to be displayed to the user as a single notification. The value should not
+	// exceed 64 bytes.
 	CollapseID string
 
 	// A string containing hexadecimal bytes of the device token for the target device.
@@ -46,6 +47,10 @@ type Notification struct {
 	// header and your APNs certificate does not specify multiple topics, the APNs
 	// server uses the certificate’s Subject as the default topic.
 	Topic string
+
+	// An optional app specific identifier. When displaying notifications, the
+	// system visually groups notifications with the same thread identifier together.
+	ThreadID string
 
 	// An optional time at which the notification is no longer valid and can be
 	// discarded by APNs. If this value is in the past, APNs treats the


### PR DESCRIPTION
When displaying notifications, the system visually groups notifications
with the same thread identifier together.

Fixes #40