### PR TITLE
request with context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
 
 install:
   - go get golang.org/x/net/http2
+  - go get golang.org/x/net/context
   - go get golang.org/x/crypto/pkcs12
 
 os:

--- a/client.go
+++ b/client.go
@@ -4,16 +4,12 @@
 package apns2
 
 import (
-	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 )
 
@@ -89,48 +85,15 @@ func (c *Client) Production() *Client {
 	return c
 }
 
-// Push sends a Notification to the APNs gateway.
-// It wraps PushWithCtx for back compatibility.
-func (c *Client) Push(n *Notification) (*Response, error) {
-	return c.PushWithCtx(n, nil)
-}
-
 // Push sends a Notification to the APNs gateway. If the underlying http.Client
 // is not currently connected, this method will attempt to reconnect
 // transparently before sending the notification. It will return a Response
 // indicating whether the notification was accepted or rejected by the APNs
 // gateway, or an error if something goes wrong.
 //
-// Context with deadline allows to close long request when context timeout exceed. It can be nil, for back compatibility
-func (c *Client) PushWithCtx(n *Notification, ctx context.Context) (*Response, error) {
-	payload, err := json.Marshal(n)
-	if err != nil {
-		return nil, err
-	}
-
-	url := fmt.Sprintf("%v/3/device/%v", c.Host, n.DeviceToken)
-	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(payload))
-
-	// add a context to request if exists
-	if ctx != nil {
-		req = req.WithContext(ctx)
-	}
-	setHeaders(req, n)
-	httpRes, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer httpRes.Body.Close()
-
-	response := &Response{}
-	response.StatusCode = httpRes.StatusCode
-	response.ApnsID = httpRes.Header.Get("apns-id")
-
-	decoder := json.NewDecoder(httpRes.Body)
-	if err := decoder.Decode(&response); err != nil && err != io.EOF {
-		return &Response{}, err
-	}
-	return response, nil
+// It wraps PushWithCtx for back compatibility.
+func (c *Client) Push(n *Notification) (*Response, error) {
+	return c.PushWithCtx(n, nil)
 }
 
 func setHeaders(r *http.Request, n *Notification) {

--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"time"
 
+	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 )
 
@@ -88,20 +89,32 @@ func (c *Client) Production() *Client {
 	return c
 }
 
+// Push sends a Notification to the APNs gateway.
+// It wraps PushWithCtx for back compatibility.
+func (c *Client) Push(n *Notification) (*Response, error) {
+	return c.PushWithCtx(n, nil)
+}
+
 // Push sends a Notification to the APNs gateway. If the underlying http.Client
 // is not currently connected, this method will attempt to reconnect
 // transparently before sending the notification. It will return a Response
 // indicating whether the notification was accepted or rejected by the APNs
 // gateway, or an error if something goes wrong.
-func (c *Client) Push(n *Notification) (*Response, error) {
+//
+// Context with deadline allows to close long request when context timeout exceed. It can be nil, for back compatibility
+func (c *Client) PushWithCtx(n *Notification, ctx context.Context) (*Response, error) {
 	payload, err := json.Marshal(n)
-
 	if err != nil {
 		return nil, err
 	}
 
 	url := fmt.Sprintf("%v/3/device/%v", c.Host, n.DeviceToken)
 	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+
+	// add a context to request if exists
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
 	setHeaders(req, n)
 	httpRes, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/client_push_go17.go
+++ b/client_push_go17.go
@@ -1,0 +1,50 @@
+// +build go1.7
+
+package apns2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Push sends a Notification to the APNs gateway. If the underlying http.Client
+// is not currently connected, this method will attempt to reconnect
+// transparently before sending the notification. It will return a Response
+// indicating whether the notification was accepted or rejected by the APNs
+// gateway, or an error if something goes wrong.
+//
+// Context with deadline allows to close long request when context timeout exceed. It can be nil, for back compatibility
+func (c *Client) PushWithCtx(n *Notification, ctx context.Context) (*Response, error) {
+	payload, err := json.Marshal(n)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%v/3/device/%v", c.Host, n.DeviceToken)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+
+	// add a context to request if exists
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	setHeaders(req, n)
+	httpRes, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer httpRes.Body.Close()
+
+	response := &Response{}
+	response.StatusCode = httpRes.StatusCode
+	response.ApnsID = httpRes.Header.Get("apns-id")
+
+	decoder := json.NewDecoder(httpRes.Body)
+	if err := decoder.Decode(&response); err != nil && err != io.EOF {
+		return &Response{}, err
+	}
+	return response, nil
+}

--- a/client_push_go17_test.go
+++ b/client_push_go17_test.go
@@ -1,0 +1,46 @@
+// +build go1.7
+
+package apns2_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_PushWithCtx_WithTimeout(t *testing.T) {
+	const timeout = time.Nanosecond
+	n := mockNotification()
+	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("apns-id", apnsID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	time.Sleep(timeout)
+	res, err := mockClient(server.URL).PushWithCtx(n, ctx)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+}
+
+func TestClient_PushWithCtx(t *testing.T) {
+	n := mockNotification()
+	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("apns-id", apnsID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	res, err := mockClient(server.URL).PushWithCtx(n, context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, res.ApnsID, apnsID)
+}

--- a/client_push_pre_go17.go
+++ b/client_push_pre_go17.go
@@ -1,0 +1,53 @@
+// +build !go1.7
+
+package apns2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+// Push sends a Notification to the APNs gateway. If the underlying http.Client
+// is not currently connected, this method will attempt to reconnect
+// transparently before sending the notification. It will return a Response
+// indicating whether the notification was accepted or rejected by the APNs
+// gateway, or an error if something goes wrong.
+//
+// Context with deadline allows to close long request when context timeout exceed. It can be nil, for back compatibility
+func (c *Client) PushWithCtx(n *Notification, ctx context.Context) (*Response, error) {
+	var httpRes *http.Response
+	payload, err := json.Marshal(n)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%v/3/device/%v", c.Host, n.DeviceToken)
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+
+	setHeaders(req, n)
+	if ctx != nil {
+		httpRes, err = ctxhttp.Do(ctx, c.HTTPClient, req)
+	} else {
+		httpRes, err = c.HTTPClient.Do(req)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer httpRes.Body.Close()
+
+	response := &Response{}
+	response.StatusCode = httpRes.StatusCode
+	response.ApnsID = httpRes.Header.Get("apns-id")
+
+	decoder := json.NewDecoder(httpRes.Body)
+	if err := decoder.Decode(&response); err != nil && err != io.EOF {
+		return &Response{}, err
+	}
+	return response, nil
+}

--- a/client_push_pre_go17_test.go
+++ b/client_push_pre_go17_test.go
@@ -1,0 +1,46 @@
+// +build !go1.7
+
+package apns2_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+func TestClient_PushWithCtx_WithTimeout(t *testing.T) {
+	const timeout = time.Nanosecond
+	n := mockNotification()
+	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("apns-id", apnsID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	time.Sleep(timeout)
+	res, err := mockClient(server.URL).PushWithCtx(n, ctx)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+}
+
+func TestClient_PushWithCtx(t *testing.T) {
+	n := mockNotification()
+	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("apns-id", apnsID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	res, err := mockClient(server.URL).PushWithCtx(n, context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, res.ApnsID, apnsID)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -16,7 +16,6 @@ import (
 	apns "github.com/sideshow/apns2"
 	"github.com/sideshow/apns2/certificate"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 // Mocks
@@ -168,24 +167,6 @@ func TestBadPayload(t *testing.T) {
 	n.Payload = func() {}
 	_, err := mockClient("").Push(n)
 	assert.Error(t, err)
-}
-
-func TestClient_PushWithCtx(t *testing.T) {
-	const timeout = time.Nanosecond
-	n := mockNotification()
-	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.Header().Set("apns-id", apnsID)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	ctx, _ := context.WithTimeout(context.Background(), timeout)
-	time.Sleep(timeout)
-	res, err := mockClient(server.URL).PushWithCtx(n, ctx)
-	assert.Error(t, err)
-	assert.Nil(t, res)
 }
 
 func Test200SuccessResponse(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -16,6 +16,7 @@ import (
 	apns "github.com/sideshow/apns2"
 	"github.com/sideshow/apns2/certificate"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 // Mocks
@@ -167,6 +168,24 @@ func TestBadPayload(t *testing.T) {
 	n.Payload = func() {}
 	_, err := mockClient("").Push(n)
 	assert.Error(t, err)
+}
+
+func TestClient_PushWithCtx(t *testing.T) {
+	const timeout = time.Nanosecond
+	n := mockNotification()
+	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("apns-id", apnsID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	time.Sleep(timeout)
+	res, err := mockClient(server.URL).PushWithCtx(n, ctx)
+	assert.Error(t, err)
+	assert.Nil(t, res)
 }
 
 func Test200SuccessResponse(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -70,8 +70,8 @@ func TestClientBadTransportError(t *testing.T) {
 }
 
 func TestClientNameToCertificate(t *testing.T) {
-	certificate, _ := certificate.FromP12File("certificate/_fixtures/certificate-valid.p12", "")
-	client := apns.NewClient(certificate)
+	crt, _ := certificate.FromP12File("certificate/_fixtures/certificate-valid.p12", "")
+	client := apns.NewClient(crt)
 	name := client.HTTPClient.Transport.(*http2.Transport).TLSClientConfig.NameToCertificate
 	assert.Len(t, name, 1)
 
@@ -83,8 +83,8 @@ func TestClientNameToCertificate(t *testing.T) {
 
 func TestDialTLSTimeout(t *testing.T) {
 	apns.TLSDialTimeout = 1 * time.Millisecond
-	certificate, _ := certificate.FromP12File("certificate/_fixtures/certificate-valid.p12", "")
-	client := apns.NewClient(certificate)
+	crt, _ := certificate.FromP12File("certificate/_fixtures/certificate-valid.p12", "")
+	client := apns.NewClient(crt)
 	dialTLS := client.HTTPClient.Transport.(*http2.Transport).DialTLS
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
With context you can to cancel request when it goes longer than necessary https://godoc.org/context#WithTimeout

`import "context"` works only >= go1.7, so i divided PushWithCtx method along with build tags `!go1.7` and `go1.7` into the distinct files with "net/context" and "context" respectively