### PR TITLE
fix data race

### DIFF
--- a/client_manager.go
+++ b/client_manager.go
@@ -20,30 +20,24 @@ type ClientFactory func(tls.Certificate) *Client
 // ManagerOpts is the func to set options to the connection manager
 type ManagerOpts func(c *manager) error
 
-// MaxSize is the maximum number of clients allowed in the manager. When
-// this limit is reached, the least recently used client is evicted. Set
-// zero for no limit.
-func MaxSize(size int) ManagerOpts {
+// SetMaxSize sets the maximum number of clients allowed in the manager.
+func SetMaxSize(size int) ManagerOpts {
 	return func(c *manager) error {
 		c.maxSize = size
 		return nil
 	}
 }
 
-// MaxAge is the maximum age of clients in the manager. Upon retrieval, if
-// a client has remained unused in the manager for this duration or longer,
-// it is evicted and nil is returned. Set zero to disable this
-// functionality.
-func MaxAge(age time.Duration) ManagerOpts {
+// SetMaxAge sets the maximum age of clients in the manager.
+func SetMaxAge(age time.Duration) ManagerOpts {
 	return func(c *manager) error {
 		c.maxAge = age
 		return nil
 	}
 }
 
-// Factory is the function which constructs clients if not found in the
-// manager.
-func Factory(f ClientFactory) ManagerOpts {
+// SetFactory sets the function which constructs new clients.
+func SetFactory(f ClientFactory) ManagerOpts {
 	return func(c *manager) error {
 		c.factory = f
 		return nil

--- a/client_manager_test.go
+++ b/client_manager_test.go
@@ -25,9 +25,9 @@ func TestNewClientManagerWithOpts(t *testing.T) {
 		return nil
 	}
 	manager := apns2.NewClientManager(
-		apns2.MaxSize(1),
-		apns2.MaxAge(time.Microsecond),
-		apns2.Factory(fn),
+		apns2.SetMaxSize(1),
+		apns2.SetMaxAge(time.Microsecond),
+		apns2.SetFactory(fn),
 	)
 
 	p1 := reflect.ValueOf(apns2.ClientFactory(fn)).Pointer()
@@ -41,8 +41,8 @@ func TestNewClientManagerWithOpts(t *testing.T) {
 func TestClientManagerAdd(t *testing.T) {
 	wg := sync.WaitGroup{}
 	manager := apns2.NewClientManager(
-		apns2.MaxSize(1),
-		apns2.MaxAge(5*time.Minute),
+		apns2.SetMaxSize(1),
+		apns2.SetMaxAge(5*time.Minute),
 	)
 
 	for i := 0; i < 2; i++ {
@@ -69,7 +69,7 @@ func TestClientManagerGetDefaultOptions(t *testing.T) {
 
 func TestClientManagerGetNilClientFactory(t *testing.T) {
 	manager := apns2.NewClientManager(
-		apns2.Factory(func(certificate tls.Certificate) *apns2.Client {
+		apns2.SetFactory(func(certificate tls.Certificate) *apns2.Client {
 			return nil
 		}),
 	)
@@ -81,7 +81,7 @@ func TestClientManagerGetNilClientFactory(t *testing.T) {
 }
 
 func TestClientManagerGetMaxAgeExpiration(t *testing.T) {
-	manager := apns2.NewClientManager(apns2.MaxAge(time.Nanosecond))
+	manager := apns2.NewClientManager(apns2.SetMaxAge(time.Nanosecond))
 	c1 := manager.Get(mockCert())
 	time.Sleep(time.Microsecond)
 	c2 := manager.Get(mockCert())
@@ -94,10 +94,10 @@ func TestClientManagerGetMaxAgeExpiration(t *testing.T) {
 
 func TestClientManagerGetMaxAgeExpirationWithNilFactory(t *testing.T) {
 	manager := apns2.NewClientManager(
-		apns2.Factory(func(certificate tls.Certificate) *apns2.Client {
+		apns2.SetFactory(func(certificate tls.Certificate) *apns2.Client {
 			return nil
 		}),
-		apns2.MaxAge(time.Nanosecond),
+		apns2.SetMaxAge(time.Nanosecond),
 	)
 	manager.Add(apns2.NewClient(mockCert()))
 	c1 := manager.Get(mockCert())
@@ -109,7 +109,7 @@ func TestClientManagerGetMaxAgeExpirationWithNilFactory(t *testing.T) {
 }
 
 func TestClientManagerGetMaxSizeExceeded(t *testing.T) {
-	manager := apns2.NewClientManager(apns2.MaxSize(1))
+	manager := apns2.NewClientManager(apns2.SetMaxSize(1))
 	cert1 := mockCert()
 	_ = manager.Get(cert1)
 	cert2, _ := certificate.FromP12File("certificate/_fixtures/certificate-valid.p12", "")
@@ -126,7 +126,7 @@ func TestClientManagerAdd2(t *testing.T) {
 		return nil
 	}
 
-	manager := apns2.NewClientManager(apns2.Factory(fn))
+	manager := apns2.NewClientManager(apns2.SetFactory(fn))
 	manager.Add(apns2.NewClient(mockCert()))
 	manager.Get(mockCert())
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,28 @@
+// this file is used to test white box cases
+package apns2
+
+import "time"
+
+func GetMaxSize(mi ClientManager) int {
+	if m, ok := mi.(*manager); ok {
+		return m.maxSize
+	}
+
+	return 0
+}
+
+func GetMaxAge(mi ClientManager) time.Duration {
+	if m, ok := mi.(*manager); ok {
+		return m.maxAge
+	}
+
+	return time.Duration(0)
+}
+
+func GetFactory(mi ClientManager) ClientFactory {
+	if m, ok := mi.(*manager); ok {
+		return m.factory
+	}
+
+	return nil
+}


### PR DESCRIPTION
fix #58

Now you can to create a ClientManager only from `NewClientManager`, and pass additional options to constructor to specify a some of custom filed if you need. For example:

```go
manager := apns2.NewClientManager(
	apns2.SetMaxSize(50),
	apns2.SetMaxAge(time.Minute),
	apns2.SetFactory(func(certificate tls.Certificate) *apns2.Client {
		// load client
	}),
)
```

or simple creation with default values

```go
manager := apns2.NewClientManager()
```

and `apns2.NewClientManager` returns the new ClientManager interface
```go
type ClientManager interface {
	Add(*Client)
	Get(tls.Certificate) *Client
	Len() int
}
```

It allows to restrict access to the manager fields and avoid a creation object of a manager without execute an suspicious`initInternal`