### PR TITLE
Fix incorrect thread-id implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,9 +131,6 @@ func setHeaders(r *http.Request, n *Notification) {
 	if n.CollapseID != "" {
 		r.Header.Set("apns-collapse-id", n.CollapseID)
 	}
-	if n.ThreadID != "" {
-		r.Header.Set("thread-id", n.ThreadID)
-	}
 	if n.Priority > 0 {
 		r.Header.Set("apns-priority", fmt.Sprintf("%v", n.Priority))
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -133,7 +133,6 @@ func TestHeaders(t *testing.T) {
 	n := mockNotification()
 	n.ApnsID = "84DB694F-464F-49BD-960A-D6DB028335C9"
 	n.CollapseID = "game1.start.identifier"
-	n.ThreadID = "game1.thread.1"
 	n.Topic = "com.testapp"
 	n.Priority = 10
 	n.Expiration = time.Now()
@@ -141,7 +140,6 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, n.ApnsID, r.Header.Get("apns-id"))
 		assert.Equal(t, n.CollapseID, r.Header.Get("apns-collapse-id"))
 		assert.Equal(t, "10", r.Header.Get("apns-priority"))
-		assert.Equal(t, n.ThreadID, r.Header.Get("thread-id"))
 		assert.Equal(t, n.Topic, r.Header.Get("apns-topic"))
 		assert.Equal(t, fmt.Sprintf("%v", n.Expiration.Unix()), r.Header.Get("apns-expiration"))
 	}))

--- a/notification.go
+++ b/notification.go
@@ -48,10 +48,6 @@ type Notification struct {
 	// server uses the certificate’s Subject as the default topic.
 	Topic string
 
-	// An optional app specific identifier. When displaying notifications, the
-	// system visually groups notifications with the same thread identifier together.
-	ThreadID string
-
 	// An optional time at which the notification is no longer valid and can be
 	// discarded by APNs. If this value is in the past, APNs treats the
 	// notification as if it expires immediately and does not store the

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -15,9 +15,10 @@ type aps struct {
 	Badge            interface{} `json:"badge,omitempty"`
 	Category         string      `json:"category,omitempty"`
 	ContentAvailable int         `json:"content-available,omitempty"`
-	URLArgs          []string    `json:"url-args,omitempty"`
-	Sound            string      `json:"sound,omitempty"`
 	MutableContent   int         `json:"mutable-content,omitempty"`
+	Sound            string      `json:"sound,omitempty"`
+	ThreadID         string      `json:"thread-id,omitempty"`
+	URLArgs          []string    `json:"url-args,omitempty"`
 }
 
 type alert struct {
@@ -246,6 +247,19 @@ func (p *Payload) Category(category string) *Payload {
 //	{"aps":{}:"mdm":mdm}
 func (p *Payload) Mdm(mdm string) *Payload {
 	p.content["mdm"] = mdm
+	return p
+}
+
+// ThreadID sets the aps thread id on the payload.
+// This is for the purpose of updating the contents of a View Controller in a
+// Notification Content app extension when a new notification arrives. If a
+// new notification arrives whose thread-id value matches the thread-id of the
+// notification already being displayed, the didReceiveNotification method
+// is called.
+//
+//	{"aps":{"thread-id":id}}
+func (p *Payload) ThreadID(threadID string) *Payload {
+	p.aps().ThreadID = threadID
 	return p
 }
 

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -142,6 +142,12 @@ func TestMdm(t *testing.T) {
 	assert.Equal(t, `{"aps":{},"mdm":"996ac527-9993-4a0a-8528-60b2b3c2f52b"}`, string(b))
 }
 
+func TestThreadID(t *testing.T) {
+	payload := NewPayload().ThreadID("THREAD_ID")
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"thread-id":"THREAD_ID"}}`, string(b))
+}
+
 func TestURLArgs(t *testing.T) {
 	payload := NewPayload().URLArgs([]string{"a", "b"})
 	b, _ := json.Marshal(payload)


### PR DESCRIPTION
Fixes issue #61 by removing thread-id from the Notification struct.
You now add a thread-id to the aps payload as per Apple docs.
See https://github.com/sideshow/apns2/pull/41#issuecomment-266804527 for discussion.