### PR TITLE
Fix race condition in ClientManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ os:
   - linux
 
 script:
-  - go test -v ./...
+  - go test -race -v ./...
   - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/client_manager_test.go
+++ b/client_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,6 +44,25 @@ func TestClientManagerAddWithoutNew(t *testing.T) {
 
 	manager.Add(apns2.NewClient(mockCert()))
 	assert.Equal(t, 1, manager.Len())
+}
+
+func TestClientManagerAddWithoutNewRace(t *testing.T) {
+	wg := sync.WaitGroup{}
+	manager := apns2.ClientManager{
+		MaxSize: 1,
+		MaxAge:  5 * time.Minute,
+		Factory: apns2.NewClient,
+	}
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			manager.Add(apns2.NewClient(mockCert()))
+			assert.Equal(t, 1, manager.Len())
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 func TestClientManagerLenWithoutNew(t *testing.T) {


### PR DESCRIPTION
Fixes original issue: https://github.com/sideshow/apns2/issues/58
Alternative to: https://github.com/sideshow/apns2/pull/59

Thank you @xjewer for reporting the data race.

This pull request, unlike https://github.com/sideshow/apns2/pull/59, involves no change in the public API. It also (still) allows instantiation of ClientManager with the `NewClientManager` constructor or long-form, e.g: 

```go
manager := apns2.ClientManager{
	MaxSize: 32,
	MaxAge:  5 * time.Minute,
	Factory: fn,
}
```

By using a package-level mutex that is preinitialized, we can lock `initInternals`. 

I added the test outlined in https://github.com/sideshow/apns2/issues/58, but perhaps more data race tests are needed.