### PR TITLE
parse pkcs8 if pkcs1 fails

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -24,6 +24,9 @@ var (
 	ErrNoPrivateKey                 = errors.New("no private key")
 	ErrNoCertificate                = errors.New("no certificate")
 	ErrUnknownPrivateKeyType        = errors.New("unknown private key type in PKCS#8 wrapping")
+
+	ParsePKCS1PrivateKey = x509.ParsePKCS1PrivateKey
+	ParsePKCS8PrivateKey = x509.ParsePKCS8PrivateKey
 )
 
 // FromP12File loads a PKCS#12 certificate from a local file and returns a
@@ -124,10 +127,10 @@ func unencryptPrivateKey(block *pem.Block, password string) (crypto.PrivateKey, 
 
 func parsePrivateKey(bytes []byte) (crypto.PrivateKey, error) {
 
-	if key, err := x509.ParsePKCS1PrivateKey(bytes); err == nil {
+	if key, err := ParsePKCS1PrivateKey(bytes); err == nil {
 		return key, nil
 	}
-	if key, err := x509.ParsePKCS8PrivateKey(bytes); err == nil {
+	if key, err := ParsePKCS8PrivateKey(bytes); err == nil {
 		switch key := key.(type) {
 		case *rsa.PrivateKey, *ecdsa.PrivateKey:
 			return key, nil

--- a/certificate/certificate_test.go
+++ b/certificate/certificate_test.go
@@ -1,7 +1,9 @@
-package certificate_test
+package certificate
 
 import (
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"io/ioutil"
 	"testing"
@@ -11,6 +13,65 @@ import (
 )
 
 // PKCS#12
+
+func TestParsePrivateKey(t *testing.T) {
+	mockErr := errors.New("Fake-Error")
+	success1Key := &rsa.PrivateKey{}
+	success8Key := &rsa.PrivateKey{}
+	fail1Key := &rsa.PrivateKey{}
+	fail8Key := &rsa.PrivateKey{}
+
+	// mock out private key parsing. No need to test that x509.ParsePKCS* funcs work
+	// These mocks will still work with real certificate data to call x509 parse functions
+	ParsePKCS8PrivateKey = func(der []byte) (interface{}, error) {
+		if string(der) == "testpkcs8" {
+			return success8Key, nil
+		}
+		if string(der)[:9] == "test-fail" {
+			return fail8Key, mockErr
+		}
+		return x509.ParsePKCS8PrivateKey(der)
+	}
+
+	ParsePKCS1PrivateKey = func(der []byte) (*rsa.PrivateKey, error) {
+		if string(der) == "testpkcs1" {
+			return success1Key, nil
+		}
+		if string(der)[:4] == "test" {
+			return fail1Key, mockErr
+		}
+		return x509.ParsePKCS1PrivateKey(der)
+	}
+
+	defer func() {
+		ParsePKCS1PrivateKey = x509.ParsePKCS1PrivateKey
+		ParsePKCS8PrivateKey = x509.ParsePKCS8PrivateKey
+	}()
+
+	type Test struct {
+		input  string
+		output interface{}
+		err    error
+	}
+
+	tests := []Test{
+		{input: "testpkcs1", output: success1Key, err: nil},
+		{input: "testpkcs8", output: success8Key, err: nil},
+		{input: "test-failpkcs1", output: nil, err: ErrFailedToParsePKCS1PrivateKey},
+		{input: "test-failpkcs8", output: nil, err: ErrFailedToParsePKCS1PrivateKey},
+	}
+
+	for _, test := range tests {
+		key, err := parsePrivateKey([]byte(test.input))
+		if err != test.err {
+			t.Fatal("Unexpected error", err, test.err)
+		}
+		if key != test.output {
+			t.Fatal("Unexpected key", key, test.output)
+		}
+	}
+
+}
 
 func TestValidCertificateFromP12File(t *testing.T) {
 	cer, err := certificate.FromP12File("_fixtures/certificate-valid.p12", "")

--- a/certificate/certificate_test.go
+++ b/certificate/certificate_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/sideshow/apns2/certificate"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,32 +73,32 @@ func TestParsePrivateKey(t *testing.T) {
 }
 
 func TestValidCertificateFromP12File(t *testing.T) {
-	cer, err := certificate.FromP12File("_fixtures/certificate-valid.p12", "")
+	cer, err := FromP12File("_fixtures/certificate-valid.p12", "")
 	assert.Nil(t, err)
 	assert.Nil(t, verifyHostname(cer))
 }
 
 func TestValidCertificateFromP12Bytes(t *testing.T) {
 	bytes, _ := ioutil.ReadFile("_fixtures/certificate-valid.p12")
-	cer, err := certificate.FromP12Bytes(bytes, "")
+	cer, err := FromP12Bytes(bytes, "")
 	assert.NoError(t, err)
 	assert.Nil(t, verifyHostname(cer))
 }
 
 func TestEncryptedValidCertificateFromP12File(t *testing.T) {
-	cer, err := certificate.FromP12File("_fixtures/certificate-valid-encrypted.p12", "password")
+	cer, err := FromP12File("_fixtures/certificate-valid-encrypted.p12", "password")
 	assert.NoError(t, err)
 	assert.Nil(t, verifyHostname(cer))
 }
 
 func TestNoSuchFileP12File(t *testing.T) {
-	cer, err := certificate.FromP12File("", "")
+	cer, err := FromP12File("", "")
 	assert.Equal(t, errors.New("open : no such file or directory").Error(), err.Error())
 	assert.Equal(t, tls.Certificate{}, cer)
 }
 
 func TestBadPasswordP12File(t *testing.T) {
-	cer, err := certificate.FromP12File("_fixtures/certificate-valid-encrypted.p12", "")
+	cer, err := FromP12File("_fixtures/certificate-valid-encrypted.p12", "")
 	assert.Equal(t, tls.Certificate{}, cer)
 	assert.Equal(t, errors.New("pkcs12: decryption password incorrect").Error(), err.Error())
 }
@@ -107,52 +106,52 @@ func TestBadPasswordP12File(t *testing.T) {
 // PEM
 
 func TestValidCertificateFromPemFile(t *testing.T) {
-	cer, err := certificate.FromPemFile("_fixtures/certificate-valid.pem", "")
+	cer, err := FromPemFile("_fixtures/certificate-valid.pem", "")
 	assert.NoError(t, err)
 	assert.Nil(t, verifyHostname(cer))
 }
 
 func TestValidCertificateFromPemBytes(t *testing.T) {
 	bytes, _ := ioutil.ReadFile("_fixtures/certificate-valid.pem")
-	cer, err := certificate.FromPemBytes(bytes, "")
+	cer, err := FromPemBytes(bytes, "")
 	assert.NoError(t, err)
 	assert.Nil(t, verifyHostname(cer))
 }
 
 func TestEncryptedValidCertificateFromPemFile(t *testing.T) {
-	cer, err := certificate.FromPemFile("_fixtures/certificate-valid-encrypted.pem", "password")
+	cer, err := FromPemFile("_fixtures/certificate-valid-encrypted.pem", "password")
 	assert.NoError(t, err)
 	assert.Nil(t, verifyHostname(cer))
 }
 
 func TestNoSuchFilePemFile(t *testing.T) {
-	cer, err := certificate.FromPemFile("", "")
+	cer, err := FromPemFile("", "")
 	assert.Equal(t, tls.Certificate{}, cer)
 	assert.Equal(t, errors.New("open : no such file or directory").Error(), err.Error())
 }
 
 func TestBadPasswordPemFile(t *testing.T) {
-	cer, err := certificate.FromPemFile("_fixtures/certificate-valid-encrypted.pem", "badpassword")
+	cer, err := FromPemFile("_fixtures/certificate-valid-encrypted.pem", "badpassword")
 	assert.Equal(t, tls.Certificate{}, cer)
-	assert.Equal(t, certificate.ErrFailedToDecryptKey, err)
+	assert.Equal(t, ErrFailedToDecryptKey, err)
 }
 
 func TestBadKeyPemFile(t *testing.T) {
-	cer, err := certificate.FromPemFile("_fixtures/certificate-bad-key.pem", "")
+	cer, err := FromPemFile("_fixtures/certificate-bad-key.pem", "")
 	assert.Equal(t, tls.Certificate{}, cer)
-	assert.Equal(t, certificate.ErrFailedToParsePKCS1PrivateKey, err)
+	assert.Equal(t, ErrFailedToParsePKCS1PrivateKey, err)
 }
 
 func TestNoKeyPemFile(t *testing.T) {
-	cer, err := certificate.FromPemFile("_fixtures/certificate-no-key.pem", "")
+	cer, err := FromPemFile("_fixtures/certificate-no-key.pem", "")
 	assert.Equal(t, tls.Certificate{}, cer)
-	assert.Equal(t, certificate.ErrNoPrivateKey, err)
+	assert.Equal(t, ErrNoPrivateKey, err)
 }
 
 func TestNoCertificatePemFile(t *testing.T) {
-	cer, err := certificate.FromPemFile("_fixtures/certificate-no-certificate.pem", "")
+	cer, err := FromPemFile("_fixtures/certificate-no-pem", "")
 	assert.Equal(t, tls.Certificate{}, cer)
-	assert.Equal(t, certificate.ErrNoCertificate, err)
+	assert.Equal(t, ErrNoCertificate, err)
 }
 
 func verifyHostname(cert tls.Certificate) error {


### PR DESCRIPTION
We are using the pkcs8 certificate. This fixes parsing the certificate in this scenario.