### PR TITLE
http2 internal pool poc

### DIFF
--- a/pool_manager.go
+++ b/pool_manager.go
@@ -1,0 +1,101 @@
+package apns2
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/idna"
+)
+
+type poolManager struct {
+	connPool http2.ClientConnPool
+	ctx      context.Context
+	poolMu   *sync.Mutex
+	u        *url.URL
+}
+
+// directly copied from source
+func authorityAddr(scheme string, authority string) (addr string) {
+	host, port, err := net.SplitHostPort(authority)
+	if err != nil {
+		port = "443"
+		if scheme == "http" {
+			port = "80"
+		}
+		host = authority
+	}
+	if a, err := idna.ToASCII(host); err == nil {
+		host = a
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return host + ":" + port
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func newPoolManager(transport *http2.Transport, environment string) (*poolManager, error) {
+	transport.CloseIdleConnections()
+	rf := reflect.Indirect(reflect.ValueOf(transport)).FieldByName("connPoolOrDef")
+	connPool := *(*http2.ClientConnPool)(unsafe.Pointer(rf.UnsafeAddr()))
+	rf = reflect.Indirect(reflect.ValueOf(connPool)).FieldByName("mu")
+	poolMu := (*sync.Mutex)(unsafe.Pointer(rf.UnsafeAddr()))
+	u, err := url.Parse(environment)
+	if err != nil {
+		return nil, err
+	}
+	return &poolManager{
+		connPool: connPool,
+		u:        u,
+		poolMu:   poolMu,
+		ctx:      context.Background(),
+	}, nil
+}
+
+func (pm *poolManager) addNewConn() error {
+	rff := reflect.Indirect(reflect.ValueOf(pm.connPool)).FieldByName("conns")
+	pm.poolMu.Lock()
+	internalConns := *(*map[string][]*http2.ClientConn)(unsafe.Pointer(rff.UnsafeAddr()))
+	pm.poolMu.Unlock()
+	for _, conns := range internalConns {
+		for _, conn := range conns {
+			rv := reflect.Indirect(reflect.ValueOf(conn))
+			rf := rv.FieldByName("mu")
+			mu := (*sync.Mutex)(unsafe.Pointer(rf.UnsafeAddr()))
+			rf = rv.FieldByName("closed")
+			mu.Lock()
+			rf = reflect.Indirect(reflect.NewAt(rf.Type(), unsafe.Pointer(rf.UnsafeAddr())))
+			rf.SetBool(true)
+			mu.Unlock()
+			defer func() {
+				mu.Lock()
+				rf.SetBool(false)
+				mu.Unlock()
+			}()
+		}
+	}
+	cc, err := pm.connPool.GetClientConn(&http.Request{Close: false}, authorityAddr(pm.u.Scheme, pm.u.Host))
+	if err != nil {
+		return err
+	}
+	go pm.pingConn(cc)
+	return nil
+}
+
+func (pm *poolManager) pingConn(cc *http2.ClientConn) {
+	for {
+		err := cc.Ping(pm.ctx)
+		if err != nil {
+			pm.addNewConn()
+			return
+		}
+		time.Sleep(PingInverval)
+	}
+}


### PR DESCRIPTION
I'm opening this PR to spark some discussion. This code is WIP, it lacks tests and proper flow, however functional.

Here's a small summary of how the http/2 connection pooling works in Go, as far as I understand:

1. Code wants to get a new connection
2. Internals check if there are any shared and **available** connections in the pool. If there is one, it returns the said connection
3. If there are none, internals check if there's an in-flight dial already. If there is, it waits for the result then returns the opened connection
4. As the last resort, internals start a dial, wait for the result, **add** the resulting connection to the pool, then returns the connection

You can browse the code [here](https://github.com/golang/net/blob/master/http2/client_conn_pool.go#L55). Instead of writing a custom connection pool, I'm exploiting reflection here to trigger the 4th step.

First, `CloseIdleConnections` can be called to initialize the transport's internal connection pool, as seen [here](https://github.com/golang/net/blob/master/http2/transport.go#L381).

The function that checks if a connection is available is [here](https://github.com/golang/net/blob/master/http2/transport.go#L616). The most practical field to change in order to mark a connection as unavailable is `closed`. After retrieving and locking appropriate mutexes on both pool and connection level, the `closed` flag for all connections is set to `true`.

Following our scenario, the next connection request reaches step 4 since there are no "available" connections (although they are alive and well). Internals create a new connection, and add it to the pool. Since the resulting connection is obtained manually via `GetClientConn`, the returned connection can be pinged periodically in a separate goroutine.

Once the deed is done, `closed` flags for all connections in the pool are restored. Since dropped connections are cleaned automatically from the pool, when pinging fails, the desired connection amount can be sustained via `addNewConn`.

Reflected fields seem stable, they haven't been changed in 2 years. Since it is not executing on a hot path, reflect performance is not much of a concern.

Thoughts? Is it worth fleshing out, or would you be against a reflection based solution?