### PR TITLE
Add TCP Keepalive

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,6 +33,9 @@ var (
 	// HTTPClient. The timeout includes connection time, any redirects,
 	// and reading the response body.
 	HTTPClientTimeout = 60 * time.Second
+	// TCPKeepAlive specifies the keep-alive period for an active network
+	// connection. If zero, keep-alives are not enabled.
+	TCPKeepAlive = 60 * time.Second
 )
 
 // Client represents a connection with the APNs
@@ -63,7 +66,11 @@ func NewClient(certificate tls.Certificate) *Client {
 	transport := &http2.Transport{
 		TLSClientConfig: tlsConfig,
 		DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
-			return tls.DialWithDialer(&net.Dialer{Timeout: TLSDialTimeout}, network, addr, cfg)
+			dialer := &net.Dialer{
+				Timeout:   TLSDialTimeout,
+				KeepAlive: TCPKeepAlive,
+			}
+			return tls.DialWithDialer(dialer, network, addr, cfg)
 		},
 	}
 	return &Client{


### PR DESCRIPTION
Adds TCP Keepalive default of 60 seconds.
This prevents an issue on AWS (and potentially Google Cloud) where they will terminate the connection after a period of time unless it has TCP Keeplaive enabled or there is data being sent when using a NAT instance.

Before:
![screen shot 2017-09-05 at 12 22 26](https://user-images.githubusercontent.com/137756/30040681-b7a34fbc-9236-11e7-9b1f-7173b8226370.png)

After:
![screen shot 2017-09-05 at 12 22 15](https://user-images.githubusercontent.com/137756/30040682-b9533250-9236-11e7-9d97-c0ed7c471310.png)
