### PR TITLE
Update readme with correct usage of payload.NewPayload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can use raw bytes for the `notification.Payload` as above, or you can use th
 ```go
 // {"aps":{"alert":"hello","badge":1},"key":"val"}
 
-payload := apns2.NewPayload().Alert("hello").Badge(1).Custom("key", "val")
+payload := payload.NewPayload().Alert("hello").Badge(1).Custom("key", "val")
 
 notification.Payload = payload
 client.Push(notification)


### PR DESCRIPTION
Small change to make the readme a bit more friendly. I was caught up by this for a few minutes, before realizing that I had to use `payload.NewPayload`.