### PR TITLE
GenerateIfExpired ignores an error

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -68,12 +68,13 @@ func AuthKeyFromBytes(bytes []byte) (*ecdsa.PrivateKey, error) {
 
 // GenerateIfExpired checks to see if the token is about to expire and
 // generates a new token.
-func (t *Token) GenerateIfExpired() {
+func (t *Token) GenerateIfExpired() (bool, error) {
 	t.Lock()
 	defer t.Unlock()
 	if t.Expired() {
-		t.Generate()
+		return t.Generate()
 	}
+	return false, nil
 }
 
 // Expired checks to see if the token has expired.

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -73,7 +73,9 @@ func TestGenerateIfExpired(t *testing.T) {
 	token := &token.Token{
 		AuthKey: authKey,
 	}
-	token.GenerateIfExpired()
+	bool, err := token.GenerateIfExpired()
+	assert.True(t, bool)
+	assert.NoError(t, err)
 	assert.Equal(t, time.Now().Unix(), token.IssuedAt)
 }
 


### PR DESCRIPTION
Make sure to return an error if GenerateIfExpired fails.