### PR TITLE
fix  rpc client bug

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -10,6 +10,7 @@ import (
 func init(){
 	gob.Register(&Payload{})
 	gob.Register(&aps{})
+	gob.Register(&Alert{})
 }
 
 // Payload represents a notification which holds the content that will be
@@ -29,7 +30,7 @@ type aps struct {
 	URLArgs          []string    `json:"url-args,omitempty"`
 }
 
-type alert struct {
+type Alert struct {
 	Action       string   `json:"action,omitempty"`
 	ActionLocKey string   `json:"action-loc-key,omitempty"`
 	Body         string   `json:"body,omitempty"`
@@ -291,9 +292,9 @@ func (p *Payload) aps() *aps {
 	return p.Content["aps"].(*aps)
 }
 
-func (a *aps) alert() *alert {
-	if _, ok := a.Alert.(*alert); !ok {
-		a.Alert = &alert{}
+func (a *aps) alert() *Alert {
+	if _, ok := a.Alert.(*Alert); !ok {
+		a.Alert = &Alert{}
 	}
-	return a.Alert.(*alert)
+	return a.Alert.(*Alert)
 }

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -2,12 +2,20 @@
 // builder to make constructing notification payloads easier.
 package payload
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"encoding/gob"
+)
+
+func init(){
+	gob.Register(&Payload{})
+	gob.Register(&aps{})
+}
 
 // Payload represents a notification which holds the content that will be
 // marshalled as JSON.
 type Payload struct {
-	content map[string]interface{}
+	Content map[string]interface{}
 }
 
 type aps struct {
@@ -116,7 +124,7 @@ func (p *Payload) MutableContent() *Payload {
 //
 //	{"aps":{}, key:value}
 func (p *Payload) Custom(key string, val interface{}) *Payload {
-	p.content[key] = val
+	p.Content[key] = val
 	return p
 }
 
@@ -246,7 +254,7 @@ func (p *Payload) Category(category string) *Payload {
 //
 //	{"aps":{}:"mdm":mdm}
 func (p *Payload) Mdm(mdm string) *Payload {
-	p.content["mdm"] = mdm
+	p.Content["mdm"] = mdm
 	return p
 }
 
@@ -276,11 +284,11 @@ func (p *Payload) URLArgs(urlArgs []string) *Payload {
 
 // MarshalJSON returns the JSON encoded version of the Payload
 func (p *Payload) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.content)
+	return json.Marshal(p.Content)
 }
 
 func (p *Payload) aps() *aps {
-	return p.content["aps"].(*aps)
+	return p.Content["aps"].(*aps)
 }
 
 func (a *aps) alert() *alert {


### PR DESCRIPTION
when i user rpc to ios push, some error will happen:

err gob: type payload.Payload has no exported fields

err gob: type not registered for interface: payload.aps

err gob: type not registered for interface: payload.Payload

so i fix the bug