### PR TITLE
Support iOS 12 Critical Alerts

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -16,7 +16,7 @@ type aps struct {
 	Category         string      `json:"category,omitempty"`
 	ContentAvailable int         `json:"content-available,omitempty"`
 	MutableContent   int         `json:"mutable-content,omitempty"`
-	Sound            string      `json:"sound,omitempty"`
+	Sound            interface{} `json:"sound,omitempty"`
 	ThreadID         string      `json:"thread-id,omitempty"`
 	URLArgs          []string    `json:"url-args,omitempty"`
 }
@@ -84,7 +84,7 @@ func (p *Payload) UnsetBadge() *Payload {
 // This will play a sound from the app bundle, or the default sound otherwise.
 //
 //	{"aps":{"sound":sound}}
-func (p *Payload) Sound(sound string) *Payload {
+func (p *Payload) Sound(sound interface{}) *Payload {
 	p.aps().Sound = sound
 	return p
 }

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -44,6 +44,16 @@ func TestSound(t *testing.T) {
 	assert.Equal(t, `{"aps":{"sound":"Default.caf"}}`, string(b))
 }
 
+func TestSoundDictionary(t *testing.T) {
+	payload := NewPayload().Sound(map[string]interface{}{
+		"critical": 1,
+		"name":     "default",
+		"volume":   0.8,
+	})
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"sound":{"critical":1,"name":"default","volume":0.8}}}`, string(b))
+}
+
 func TestContentAvailable(t *testing.T) {
 	payload := NewPayload().ContentAvailable()
 	b, _ := json.Marshal(payload)


### PR DESCRIPTION
The aps sound field in the APNS payload can now be a dictionary in order to send critical alerts for iOS 12 devices.

You can read about it [here](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2990112). 

These changes add support for that as well as a test case.

cc @froodian