### PR TITLE
Adds support for Summary arguments in notifications (iOS 12)

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -235,6 +235,17 @@ func (p *Payload) AlertActionLocKey(key string) *Payload {
 	return p
 }
 
+// SummaryArg sets the aps alert summary arg key on the payload.
+// This is the string that is used as a key to fill in an argument
+// at the bottom of a notification to provide more context, such as
+// a name associated with the sender of the notification.
+//
+//	{"aps":{"alert":{"summary-arg":key}}}
+func (p *Payload) SummaryArg(key string) *Payload {
+	p.aps().alert().SummaryArg = key
+	return p
+}
+
 // General
 
 // Category sets the aps category on the payload.

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -246,6 +246,17 @@ func (p *Payload) SummaryArg(key string) *Payload {
 	return p
 }
 
+// SummaryArgCount sets the aps alert summary arg count key on the payload.
+// This integer sets a custom "weight" on the notification, effectively
+// allowing a notification to be viewed internally as two. For example if
+// a notification encompasses 3 messages, you can set it to 3.
+//
+//	{"aps":{"alert":{"summary-arg-count":key}}}
+func (p *Payload) SummaryArgCount(key int) *Payload {
+	p.aps().alert().SummaryArgCount = key
+	return p
+}
+
 // General
 
 // Category sets the aps category on the payload.

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -176,6 +176,18 @@ func TestSoundVolume(t *testing.T) {
 	assert.Equal(t, `{"aps":{"sound":{"critical":1,"name":"default","volume":0.5}}}`, string(b))
 }
 
+func TestSummaryArg(t *testing.T) {
+	payload := NewPayload().SummaryArg("Robert")
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":{"summary-arg":"Robert"}}}`, string(b))
+}
+
+func TestSummaryArgCount(t *testing.T) {
+	payload := NewPayload().SummaryArgCount(3)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":{"summary-arg-count":3}}}`, string(b))
+}
+	
 func TestCombined(t *testing.T) {
 	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").Custom("key", "val")
 	b, _ := json.Marshal(payload)


### PR DESCRIPTION
This pull request adds support for summary related keys in the payload that are new in iOS 12. They provide extra context into a specific notification, such as who sent the notification to make labeling the notification more easy digestible. Also includes support for summary arg count which effectively allows you to "weigh" a notification.

WWDC 2018 "Using Grouped Notifications": https://developer.apple.com/videos/play/wwdc2018/711/ (approximately 19 minutes in)

Other than the video I can't find documentation on Apple's site, but here's a written article that was useful: https://medium.com/swift-india/lets-take-quick-dive-in-grouped-notifications-5d41af9d6463