### PR TITLE
Adds support for Summary arguments in notifications for iOS 12

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -243,7 +243,7 @@ func (p *Payload) AlertActionLocKey(key string) *Payload {
 // a name associated with the sender of the notification.
 //
 //	{"aps":{"alert":{"summary-arg":key}}}
-func (p *Payload) SummaryArg(key string) *Payload {
+func (p *Payload) AlertSummaryArg(key string) *Payload {
 	p.aps().alert().SummaryArg = key
 	return p
 }
@@ -254,7 +254,7 @@ func (p *Payload) SummaryArg(key string) *Payload {
 // a notification encompasses 3 messages, you can set it to 3.
 //
 //	{"aps":{"alert":{"summary-arg-count":key}}}
-func (p *Payload) SummaryArgCount(key int) *Payload {
+func (p *Payload) AlertSummaryArgCount(key int) *Payload {
 	p.aps().alert().SummaryArgCount = key
 	return p
 }

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -176,14 +176,14 @@ func TestSoundVolume(t *testing.T) {
 	assert.Equal(t, `{"aps":{"sound":{"critical":1,"name":"default","volume":0.5}}}`, string(b))
 }
 
-func TestSummaryArg(t *testing.T) {
-	payload := NewPayload().SummaryArg("Robert")
+func TestAlertSummaryArg(t *testing.T) {
+	payload := NewPayload().AlertSummaryArg("Robert")
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":{"summary-arg":"Robert"}}}`, string(b))
 }
 
-func TestSummaryArgCount(t *testing.T) {
-	payload := NewPayload().SummaryArgCount(3)
+func TestAlertSummaryArgCount(t *testing.T) {
+	payload := NewPayload().AlertSummaryArgCount(3)
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":{"summary-arg-count":3}}}`, string(b))
 }


### PR DESCRIPTION
Based on the work of @christianselig I only renamed the methods to be consistent.
That PR replaces #118.