### PR TITLE
fix post request return eof error cause panic

### DIFF
--- a/client.go
+++ b/client.go
@@ -154,7 +154,10 @@ func (c *Client) PushWithContext(ctx Context, n *Notification) (*Response, error
 	}
 
 	url := fmt.Sprintf("%v/3/device/%v", c.Host, n.DeviceToken)
-	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
 
 	if c.Token != nil {
 		c.setTokenHeader(req)


### PR DESCRIPTION
when Post https://api.push.apple.com return eof error，http request is nil. In `setHeaders(req, n)` function, `r.Header.Set("Content-Type", "application/json; charset=utf-8")` this code will cause panic, because r(req) is nil.

