### PR TITLE
add support for http proxy

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,6 +98,9 @@ func NewClient(certificate tls.Certificate) *Client {
 // Since the transport of http1.1 does not support DialTLS with http proxy enabled
 // The DialTLS (including TLSDialTimeout and TCPKeepAlive) will be disabled if you use this function
 func NewProxyClient(certificate tls.Certificate, proxyUrl string) *Client {
+	if proxyUrl == "" {
+		return NewClient(certificate)
+	}
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{certificate},
 	}

--- a/client.go
+++ b/client.go
@@ -38,6 +38,8 @@ var (
 	// TCPKeepAlive specifies the keep-alive period for an active network
 	// connection. If zero, keep-alives are not enabled.
 	TCPKeepAlive = 60 * time.Second
+	// IdleConnTimeout specifies the max idle time of the connection
+	IdleConnTimeout = 300 * time.Second
 )
 
 // DialTLS is the default dial function for creating TLS connections for
@@ -97,6 +99,7 @@ func NewClient(certificate tls.Certificate) *Client {
 // NewProxyClient returns a new Client with http proxy enabled
 // Since the transport of http1.1 does not support DialTLS with http proxy enabled
 // The DialTLS (including TLSDialTimeout and TCPKeepAlive) will be disabled if you use this function
+// proxyUrl like http://127.0.0.1:8888
 func NewProxyClient(certificate tls.Certificate, proxyUrl string) *Client {
 	if proxyUrl == "" {
 		return NewClient(certificate)
@@ -112,6 +115,7 @@ func NewProxyClient(certificate tls.Certificate, proxyUrl string) *Client {
 		Proxy: func(request *http.Request) (*url.URL, error) {
 			return url.Parse(proxyUrl)
 		},
+		IdleConnTimeout: IdleConnTimeout,
 	}
 	err := http2.ConfigureTransport(transport)
 	//if configure failed

--- a/client_test.go
+++ b/client_test.go
@@ -66,6 +66,16 @@ func TestTokenDefaultHost(t *testing.T) {
 	assert.Equal(t, "https://api.development.push.apple.com", client.Host)
 }
 
+func TestClientProxyDefaultHost(t *testing.T) {
+	client := apns.NewProxyClient(mockCert(), "http://127.0.0.1:8888")
+	assert.Equal(t, "https://api.development.push.apple.com", client.Host)
+}
+
+func TestTokenProxyDefaultHost(t *testing.T) {
+	client := apns.NewProxyTokenClient(mockToken(), "http://127.0.0.1:8888").Development()
+	assert.Equal(t, "https://api.development.push.apple.com", client.Host)
+}
+
 func TestClientDevelopmentHost(t *testing.T) {
 	client := apns.NewClient(mockCert()).Development()
 	assert.Equal(t, "https://api.development.push.apple.com", client.Host)


### PR DESCRIPTION
I have the same problem in this issue.
https://github.com/sideshow/apns2/issues/24#issuecomment-302920438
I found that apns2 doesn't support http2 proxy. In order to fix the problem, I made some improvements to the following code.
