### PR TITLE
Update development APNS host

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ import (
 
 // Apple HTTP/2 Development & Production urls
 const (
-	HostDevelopment = "https://api.development.push.apple.com"
+	HostDevelopment = "https://api.sandbox.push.apple.com"
 	HostProduction  = "https://api.push.apple.com"
 )
 


### PR DESCRIPTION
The development APNS host url was outdated.
The new URL is `https://api.sandbox.push.apple.com`
From: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns

This should help fix issue #24, where the client used to timeout because of an invalid host url