### PR TITLE
docs fix

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -166,7 +166,7 @@ func (p *Payload) AlertTitleLocArgs(args []string) *Payload {
 // This will display a short string describing the purpose of the notification.
 // Apple Watch & Safari display this string as part of the notification interface.
 //
-//	{"aps":{"subtitle":"subtitle"}}
+//	{"aps":{"alert":{"subtitle":"subtitle"}}}
 func (p *Payload) AlertSubtitle(subtitle string) *Payload {
 	p.aps().alert().Subtitle = subtitle
 	return p


### PR DESCRIPTION
referring to the docs: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification

the code is correct putting it into the alert, but the docs are (as often is ^^) wrong