### PR TITLE
Add remainder of EPushType types

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -16,10 +16,10 @@ import (
 
 	"golang.org/x/net/http2"
 
+	apns "github.com/sideshow/apns2"
 	"github.com/sideshow/apns2/certificate"
 	"github.com/sideshow/apns2/token"
 	"github.com/stretchr/testify/assert"
-	apns "github.com/sideshow/apns2"
 )
 
 // Mocks
@@ -180,14 +180,78 @@ func TestHeaders(t *testing.T) {
 	n.Topic = "com.testapp"
 	n.Priority = 10
 	n.Expiration = time.Now()
-	n.PushType = apns.PushTypeBackground
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, n.ApnsID, r.Header.Get("apns-id"))
 		assert.Equal(t, n.CollapseID, r.Header.Get("apns-collapse-id"))
 		assert.Equal(t, "10", r.Header.Get("apns-priority"))
 		assert.Equal(t, n.Topic, r.Header.Get("apns-topic"))
 		assert.Equal(t, fmt.Sprintf("%v", n.Expiration.Unix()), r.Header.Get("apns-expiration"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
+func TestPushTypeAlertHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeAlert
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "alert", r.Header.Get("apns-push-type"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
+func TestPushTypeBackgroundHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeBackground
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "background", r.Header.Get("apns-push-type"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
+func TestPushTypeVOIPHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeVOIP
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "voip", r.Header.Get("apns-push-type"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
+func TestPushTypeComplicationHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeComplication
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "complication", r.Header.Get("apns-push-type"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
+func TestPushTypeFileProviderHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeFileProvider
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "fileprovider", r.Header.Get("apns-push-type"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
+func TestPushTypeMDMHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeMDM
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "mdm", r.Header.Get("apns-push-type"))
 	}))
 	defer server.Close()
 	_, err := mockClient(server.URL).Push(n)

--- a/notification.go
+++ b/notification.go
@@ -9,11 +9,11 @@ import (
 type EPushType string
 
 const (
-	// PushTypeAlert is used for notifications that trigger a user
-	// interaction—for example, an alert, badge, or sound. If you set this push
-	// type, the apns-topic header field must use your app’s bundle ID as the
-	// topic. The alert push type is required on watchOS 6 and later. It is
-	// recommended on macOS, iOS, tvOS, and iPadOS.
+	// PushTypeAlert is used for notifications that trigger a user interaction —
+	// for example, an alert, badge, or sound. If you set this push type, the
+	// apns-topic header field must use your app’s bundle ID as the topic. The
+	// alert push type is required on watchOS 6 and later. It is recommended on
+	// macOS, iOS, tvOS, and iPadOS.
 	PushTypeAlert EPushType = "alert"
 
 	// PushTypeBackground is used for notifications that deliver content in the
@@ -24,8 +24,7 @@ const (
 	PushTypeBackground EPushType = "background"
 
 	// PushTypeVOIP is used for notifications that provide information about an
-	// incoming Voice-over-IP (VoIP) call. For more information, see Responding
-	// to VoIP Notifications from PushKit. If you set this push type, the
+	// incoming Voice-over-IP (VoIP) call. If you set this push type, the
 	// apns-topic header field must use your app’s bundle ID with .voip appended
 	// to the end. If you’re using certificate-based authentication, you must
 	// also register the certificate for VoIP services. The voip push type is

--- a/notification.go
+++ b/notification.go
@@ -9,13 +9,48 @@ import (
 type EPushType string
 
 const (
-	//PushTypeAlert  will set the apns-push-type header to 'alert'
+	// PushTypeAlert is used for notifications that trigger a user interaction—for 
+	// example, an alert, badge, or sound. If you set this push type, the apns-topic 
+	// header field must use your app’s bundle ID as the topic. The alert push type 
+	// is required on watchOS 6 and later. It is recommended on macOS, iOS, tvOS, 
+	// and iPadOS.
 	PushTypeAlert EPushType = "alert"
-	//PushTypeBackground will set the apns-push-type header to 'background'
+
+	// PushTypeBackground is used for notifications that deliver content in the 
+	// background, and don’t trigger any user interactions. If you set this push 
+	// type, the apns-topic header field must use your app’s bundle ID as the topic.
+	// The background push type is required on watchOS 6 and later. It is recommended 
+	// on macOS, iOS, tvOS, and iPadOS.
 	PushTypeBackground EPushType = "background"
-	//PushTypeVoIP will set the apns-push-type header to 'voip' which is required
-	// for PushKit applications.
+
+	// PushTypeVoIP is used for notifications that provide information about an 
+	// incoming Voice-over-IP (VoIP) call. For more information, see Responding to 
+	// VoIP Notifications from PushKit. If you set this push type, the apns-topic 
+	// header field must use your app’s bundle ID with .voip appended to the end. 
+	// If you’re using certificate-based authentication, you must also register the 
+	// certificate for VoIP services. The voip push type is not available on watchOS. 
+	// It is recommended on macOS, iOS, tvOS, and iPadOS.
 	PushTypeVoIP EPushType = "voip"
+
+	// PushTypeComplication is used for notifications that contain update information 
+	// for a watchOS app’s complications. If you set this push type, the apns-topic 
+	// header field must use your app’s bundle ID with .complication appended to the 
+	// end. If you’re using certificate-based authentication, you must also register 
+	// the certificate for WatchKit services. The complication push type is recommended 
+	// for watchOS and iOS. It is not available on macOS, tvOS, and iPadOS.
+	PushTypeComplication EPushType = "complication"
+
+	// PushTypeFileProvider is used to signal changes to a File Provider extension. 
+	// If you set this push type, the apns-topic header field must use your app’s 
+	// bundle ID with .pushkit.fileprovider appended to the end. The fileprovider 
+	// push type is not available on watchOS. It is recommended on macOS, iOS, tvOS, 
+	// and iPadOS.
+	PushTypeFileProvider EPushType = "fileprovider"
+	
+	// PushTypeMdm is used for notifications that tell managed devices to contact 
+	// the MDM server. If you set this push type, you must use the topic from the UID 
+	// attribute in the subject of your MDM push certificate.
+	PushTypeMdm EPushType = "mdm"
 )
 
 const (

--- a/notification.go
+++ b/notification.go
@@ -5,64 +5,66 @@ import (
 	"time"
 )
 
-//EPushType defines the value for the apns-push-type header
+// EPushType defines the value for the apns-push-type header
 type EPushType string
 
 const (
-	// PushTypeAlert is used for notifications that trigger a user interaction—for 
-	// example, an alert, badge, or sound. If you set this push type, the apns-topic 
-	// header field must use your app’s bundle ID as the topic. The alert push type 
-	// is required on watchOS 6 and later. It is recommended on macOS, iOS, tvOS, 
-	// and iPadOS.
+	// PushTypeAlert is used for notifications that trigger a user
+	// interaction—for example, an alert, badge, or sound. If you set this push
+	// type, the apns-topic header field must use your app’s bundle ID as the
+	// topic. The alert push type is required on watchOS 6 and later. It is
+	// recommended on macOS, iOS, tvOS, and iPadOS.
 	PushTypeAlert EPushType = "alert"
 
-	// PushTypeBackground is used for notifications that deliver content in the 
-	// background, and don’t trigger any user interactions. If you set this push 
-	// type, the apns-topic header field must use your app’s bundle ID as the topic.
-	// The background push type is required on watchOS 6 and later. It is recommended 
-	// on macOS, iOS, tvOS, and iPadOS.
+	// PushTypeBackground is used for notifications that deliver content in the
+	// background, and don’t trigger any user interactions. If you set this push
+	// type, the apns-topic header field must use your app’s bundle ID as the
+	// topic. The background push type is required on watchOS 6 and later. It is
+	// recommended on macOS, iOS, tvOS, and iPadOS.
 	PushTypeBackground EPushType = "background"
 
-	// PushTypeVoIP is used for notifications that provide information about an 
-	// incoming Voice-over-IP (VoIP) call. For more information, see Responding to 
-	// VoIP Notifications from PushKit. If you set this push type, the apns-topic 
-	// header field must use your app’s bundle ID with .voip appended to the end. 
-	// If you’re using certificate-based authentication, you must also register the 
-	// certificate for VoIP services. The voip push type is not available on watchOS. 
-	// It is recommended on macOS, iOS, tvOS, and iPadOS.
-	PushTypeVoIP EPushType = "voip"
+	// PushTypeVOIP is used for notifications that provide information about an
+	// incoming Voice-over-IP (VoIP) call. For more information, see Responding
+	// to VoIP Notifications from PushKit. If you set this push type, the
+	// apns-topic header field must use your app’s bundle ID with .voip appended
+	// to the end. If you’re using certificate-based authentication, you must
+	// also register the certificate for VoIP services. The voip push type is
+	// not available on watchOS. It is recommended on macOS, iOS, tvOS, and
+	// iPadOS.
+	PushTypeVOIP EPushType = "voip"
 
-	// PushTypeComplication is used for notifications that contain update information 
-	// for a watchOS app’s complications. If you set this push type, the apns-topic 
-	// header field must use your app’s bundle ID with .complication appended to the 
-	// end. If you’re using certificate-based authentication, you must also register 
-	// the certificate for WatchKit services. The complication push type is recommended 
-	// for watchOS and iOS. It is not available on macOS, tvOS, and iPadOS.
+	// PushTypeComplication is used for notifications that contain update
+	// information for a watchOS app’s complications. If you set this push type,
+	// the apns-topic header field must use your app’s bundle ID with
+	// .complication appended to the end. If you’re using certificate-based
+	// authentication, you must also register the certificate for WatchKit
+	// services. The complication push type is recommended for watchOS and iOS.
+	// It is not available on macOS, tvOS, and iPadOS.
 	PushTypeComplication EPushType = "complication"
 
-	// PushTypeFileProvider is used to signal changes to a File Provider extension. 
-	// If you set this push type, the apns-topic header field must use your app’s 
-	// bundle ID with .pushkit.fileprovider appended to the end. The fileprovider 
-	// push type is not available on watchOS. It is recommended on macOS, iOS, tvOS, 
-	// and iPadOS.
+	// PushTypeFileProvider is used to signal changes to a File Provider
+	// extension. If you set this push type, the apns-topic header field must
+	// use your app’s bundle ID with .pushkit.fileprovider appended to the end.
+	// The fileprovider push type is not available on watchOS. It is recommended
+	// on macOS, iOS, tvOS, and iPadOS.
 	PushTypeFileProvider EPushType = "fileprovider"
-	
-	// PushTypeMdm is used for notifications that tell managed devices to contact 
-	// the MDM server. If you set this push type, you must use the topic from the UID 
-	// attribute in the subject of your MDM push certificate.
-	PushTypeMdm EPushType = "mdm"
+
+	// PushTypeMDM is used for notifications that tell managed devices to
+	// contact the MDM server. If you set this push type, you must use the topic
+	// from the UID attribute in the subject of your MDM push certificate.
+	PushTypeMDM EPushType = "mdm"
 )
 
 const (
 	// PriorityLow will tell APNs to send the push message at a time that takes
 	// into account power considerations for the device. Notifications with this
-	// priority might be grouped and delivered in bursts. They are throttled, and
-	// in some cases are not delivered.
+	// priority might be grouped and delivered in bursts. They are throttled,
+	// and in some cases are not delivered.
 	PriorityLow = 5
 
 	// PriorityHigh will tell APNs to send the push message immediately.
-	// Notifications with this priority must trigger an alert, sound, or badge on
-	// the target device. It is an error to use this priority for a push
+	// Notifications with this priority must trigger an alert, sound, or badge
+	// on the target device. It is an error to use this priority for a push
 	// notification that contains only the content-available key.
 	PriorityHigh = 10
 )
@@ -70,38 +72,41 @@ const (
 // Notification represents the the data and metadata for a APNs Remote Notification.
 type Notification struct {
 
-	// An optional canonical UUID that identifies the notification. The canonical
-	// form is 32 lowercase hexadecimal digits, displayed in five groups separated
-	// by hyphens in the form 8-4-4-4-12. An example UUID is as follows:
+	// An optional canonical UUID that identifies the notification. The
+	// canonical form is 32 lowercase hexadecimal digits, displayed in five
+	// groups separated by hyphens in the form 8-4-4-4-12. An example UUID is as
+	// follows:
 	//
-	// 	123e4567-e89b-12d3-a456-42665544000
+	//  123e4567-e89b-12d3-a456-42665544000
 	//
 	// If you don't set this, a new UUID is created by APNs and returned in the
 	// response.
 	ApnsID string
 
-	// A string which allows multiple notifications with the same collapse identifier
-	// to be displayed to the user as a single notification. The value should not
-	// exceed 64 bytes.
+	// A string which allows multiple notifications with the same collapse
+	// identifier to be displayed to the user as a single notification. The
+	// value should not exceed 64 bytes.
 	CollapseID string
 
-	// A string containing hexadecimal bytes of the device token for the target device.
+	// A string containing hexadecimal bytes of the device token for the target
+	// device.
 	DeviceToken string
 
-	// The topic of the remote notification, which is typically the bundle ID for
-	// your app. The certificate you create in the Apple Developer Member Center
-	// must include the capability for this topic. If your certificate includes
-	// multiple topics, you must specify a value for this header. If you omit this
-	// header and your APNs certificate does not specify multiple topics, the APNs
-	// server uses the certificate’s Subject as the default topic.
+	// The topic of the remote notification, which is typically the bundle ID
+	// for your app. The certificate you create in the Apple Developer Member
+	// Center must include the capability for this topic. If your certificate
+	// includes multiple topics, you must specify a value for this header. If
+	// you omit this header and your APNs certificate does not specify multiple
+	// topics, the APNs server uses the certificate’s Subject as the default
+	// topic.
 	Topic string
 
 	// An optional time at which the notification is no longer valid and can be
 	// discarded by APNs. If this value is in the past, APNs treats the
 	// notification as if it expires immediately and does not store the
 	// notification or attempt to redeliver it. If this value is left as the
-	// default (ie, Expiration.IsZero()) an expiration header will not added to the
-	// http request.
+	// default (ie, Expiration.IsZero()) an expiration header will not added to
+	// the http request.
 	Expiration time.Time
 
 	// The priority of the notification. Specify ether apns.PriorityHigh (10) or
@@ -114,8 +119,9 @@ type Notification struct {
 	// Remote Notification Programming Guide for more info.
 	Payload interface{}
 
-	// The pushtype of the push notification. If this values is left as the default
-	// an apns-push-type header with value 'alert' will be added to the http request.
+	// The pushtype of the push notification. If this values is left as the
+	// default an apns-push-type header with value 'alert' will be added to the
+	// http request.
 	PushType EPushType
 }
 


### PR DESCRIPTION
Adds remainder of `apns-push-type` types. According to Apple docs there are 6 possible values. https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns