### PR TITLE
fix data race

### DIFF
--- a/client.go
+++ b/client.go
@@ -198,8 +198,8 @@ func (c *Client) CloseIdleConnections() {
 }
 
 func (c *Client) setTokenHeader(r *http.Request) {
-	c.Token.GenerateIfExpired()
-	r.Header.Set("authorization", fmt.Sprintf("bearer %v", c.Token.Bearer))
+	bearer := c.Token.GenerateIfExpired()
+	r.Header.Set("authorization", fmt.Sprintf("bearer %v", bearer))
 }
 
 func setHeaders(r *http.Request, n *Notification) {

--- a/token/token.go
+++ b/token/token.go
@@ -68,12 +68,13 @@ func AuthKeyFromBytes(bytes []byte) (*ecdsa.PrivateKey, error) {
 
 // GenerateIfExpired checks to see if the token is about to expire and
 // generates a new token.
-func (t *Token) GenerateIfExpired() {
+func (t *Token) GenerateIfExpired() (bearer string) {
 	t.Lock()
 	defer t.Unlock()
 	if t.Expired() {
 		t.Generate()
 	}
+	return t.Bearer
 }
 
 // Expired checks to see if the token has expired.


### PR DESCRIPTION
We cannot refer to `t.Bearer` during `t.Generate` because we changed it during `t.Generate`.