### PR TITLE
Add iOS 15 payload additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ APNS/2 is a go package designed for simple, flexible and fast Apple Push Notific
 - Works with go 1.7 and later
 - Supports new Apple Token Based Authentication (JWT)
 - Supports new iOS 10 features such as Collapse IDs, Subtitles and Mutable Notifications
+- Supports new iOS 15 fetaures interruptionLevel and relevanceScore
 - Supports persistent connections to APNs
 - Supports VoIP/PushKit notifications (iOS 8 and later)
 - Modular & easy to use

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -11,14 +11,16 @@ type Payload struct {
 }
 
 type aps struct {
-	Alert            interface{} `json:"alert,omitempty"`
-	Badge            interface{} `json:"badge,omitempty"`
-	Category         string      `json:"category,omitempty"`
-	ContentAvailable int         `json:"content-available,omitempty"`
-	MutableContent   int         `json:"mutable-content,omitempty"`
-	Sound            interface{} `json:"sound,omitempty"`
-	ThreadID         string      `json:"thread-id,omitempty"`
-	URLArgs          []string    `json:"url-args,omitempty"`
+	Alert             interface{} `json:"alert,omitempty"`
+	Badge             interface{} `json:"badge,omitempty"`
+	Category          string      `json:"category,omitempty"`
+	ContentAvailable  int         `json:"content-available,omitempty"`
+	MutableContent    int         `json:"mutable-content,omitempty"`
+	Sound             interface{} `json:"sound,omitempty"`
+	ThreadID          string      `json:"thread-id,omitempty"`
+	URLArgs           []string    `json:"url-args,omitempty"`
+	InterruptionLevel string      `json:"interruption-level,omitempty"`
+	RelevanceScore    float32     `json:"relevance-score,omitempty"`
 }
 
 type alert struct {
@@ -321,6 +323,58 @@ func (p *Payload) SoundName(name string) *Payload {
 // {"aps":{"sound":{"critical":1,"name":"default","volume":volume}}}
 func (p *Payload) SoundVolume(volume float32) *Payload {
 	p.aps().sound().Volume = volume
+	return p
+}
+
+// InterruptionLevelPassive sets the aps interruption-level to "passive" on the payload.
+// This is to indicate the importance and delivery timing of a notification.
+// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+//
+// {"aps":{"interruption-level":passive}}
+func (p *Payload) InterruptionLevelPassive() *Payload {
+	p.aps().InterruptionLevel = "passive"
+	return p
+}
+
+// InterruptionLevelActive sets the aps interruption-level to "active" on the payload.
+// This is to indicate the importance and delivery timing of a notification.
+// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+//
+// {"aps":{"interruption-level":active}}
+func (p *Payload) InterruptionLevelActive() *Payload {
+	p.aps().InterruptionLevel = "active"
+	return p
+}
+
+// InterruptionLevelTimeSensitive sets the aps interruption-level to "time-senstive" on the payload.
+// This is to indicate the importance and delivery timing of a notification.
+// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+//
+// {"aps":{"interruption-level":time-sensitive}}
+func (p *Payload) InterruptionLevelTimeSensitive() *Payload {
+	p.aps().InterruptionLevel = "time-sensitive"
+	return p
+}
+
+// InterruptionLevelCritical sets the aps interruption-level to "critical" on the payload.
+// This is to indicate the importance and delivery timing of a notification.
+// This interruption level requires an approved entitlement from Apple.
+// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+//
+// {"aps":{"interruption-level":critical}}
+func (p *Payload) InterruptionLevelCritical() *Payload {
+	p.aps().InterruptionLevel = "critical"
+	return p
+}
+
+// The relevance score, a number between 0 and 1,
+// that the system uses to sort the notifications from your app.
+// The highest score gets featured in the notification summary.
+// See https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore.
+//
+//	{"aps":{"relevance-score":0.1}}
+func (p *Payload) RelevanceScore(b float32) *Payload {
+	p.aps().RelevanceScore = b
 	return p
 }
 

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -15,12 +15,12 @@ type aps struct {
 	Badge             interface{} `json:"badge,omitempty"`
 	Category          string      `json:"category,omitempty"`
 	ContentAvailable  int         `json:"content-available,omitempty"`
+	InterruptionLevel string      `json:"interruption-level,omitempty"`
 	MutableContent    int         `json:"mutable-content,omitempty"`
+	RelevanceScore    float32     `json:"relevance-score,omitempty"`
 	Sound             interface{} `json:"sound,omitempty"`
 	ThreadID          string      `json:"thread-id,omitempty"`
 	URLArgs           []string    `json:"url-args,omitempty"`
-	InterruptionLevel string      `json:"interruption-level,omitempty"`
-	RelevanceScore    float32     `json:"relevance-score,omitempty"`
 }
 
 type alert struct {

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -4,6 +4,25 @@ package payload
 
 import "encoding/json"
 
+// InterruptionLevel defines the value for the payload aps interruption-level
+type EInterruptionLevel string
+
+const (
+	// InterruptionLevelPassive is used to indicate that notification be delivered in a passive manner.
+	InterruptionLevelPassive EInterruptionLevel = "passive"
+
+	// InterruptionLevelActive is used to indicate the importance and delivery timing of a notification.
+	InterruptionLevelActive EInterruptionLevel = "active"
+
+	// InterruptionLevelTimeSensitive is used to indicate the importance and delivery timing of a notification.
+	InterruptionLevelTimeSensitive EInterruptionLevel = "time-sensitive"
+
+	// InterruptionLevelCritical is used to indicate the importance and delivery timing of a notification.
+	// This interruption level requires an approved entitlement from Apple.
+	// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+	InterruptionLevelCritical EInterruptionLevel = "critical"
+)
+
 // Payload represents a notification which holds the content that will be
 // marshalled as JSON.
 type Payload struct {
@@ -11,16 +30,16 @@ type Payload struct {
 }
 
 type aps struct {
-	Alert             interface{} `json:"alert,omitempty"`
-	Badge             interface{} `json:"badge,omitempty"`
-	Category          string      `json:"category,omitempty"`
-	ContentAvailable  int         `json:"content-available,omitempty"`
-	InterruptionLevel string      `json:"interruption-level,omitempty"`
-	MutableContent    int         `json:"mutable-content,omitempty"`
-	RelevanceScore    interface{} `json:"relevance-score,omitempty"`
-	Sound             interface{} `json:"sound,omitempty"`
-	ThreadID          string      `json:"thread-id,omitempty"`
-	URLArgs           []string    `json:"url-args,omitempty"`
+	Alert             interface{}        `json:"alert,omitempty"`
+	Badge             interface{}        `json:"badge,omitempty"`
+	Category          string             `json:"category,omitempty"`
+	ContentAvailable  int                `json:"content-available,omitempty"`
+	InterruptionLevel EInterruptionLevel `json:"interruption-level,omitempty"`
+	MutableContent    int                `json:"mutable-content,omitempty"`
+	RelevanceScore    interface{}        `json:"relevance-score,omitempty"`
+	Sound             interface{}        `json:"sound,omitempty"`
+	ThreadID          string             `json:"thread-id,omitempty"`
+	URLArgs           []string           `json:"url-args,omitempty"`
 }
 
 type alert struct {
@@ -326,44 +345,14 @@ func (p *Payload) SoundVolume(volume float32) *Payload {
 	return p
 }
 
-// InterruptionLevelPassive sets the aps interruption-level to "passive" on the payload.
+// InterruptionLevel defines the value for the payload aps interruption-level
 // This is to indicate the importance and delivery timing of a notification.
+// (Using InterruptionLevelCritical requires an approved entitlement from Apple.)
 // See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
 //
 // {"aps":{"interruption-level":passive}}
-func (p *Payload) InterruptionLevelPassive() *Payload {
-	p.aps().InterruptionLevel = "passive"
-	return p
-}
-
-// InterruptionLevelActive sets the aps interruption-level to "active" on the payload.
-// This is to indicate the importance and delivery timing of a notification.
-// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
-//
-// {"aps":{"interruption-level":active}}
-func (p *Payload) InterruptionLevelActive() *Payload {
-	p.aps().InterruptionLevel = "active"
-	return p
-}
-
-// InterruptionLevelTimeSensitive sets the aps interruption-level to "time-sensitive" on the payload.
-// This is to indicate the importance and delivery timing of a notification.
-// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
-//
-// {"aps":{"interruption-level":time-sensitive}}
-func (p *Payload) InterruptionLevelTimeSensitive() *Payload {
-	p.aps().InterruptionLevel = "time-sensitive"
-	return p
-}
-
-// InterruptionLevelCritical sets the aps interruption-level to "critical" on the payload.
-// This is to indicate the importance and delivery timing of a notification.
-// This interruption level requires an approved entitlement from Apple.
-// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
-//
-// {"aps":{"interruption-level":critical}}
-func (p *Payload) InterruptionLevelCritical() *Payload {
-	p.aps().InterruptionLevel = "critical"
+func (p *Payload) InterruptionLevel(interruptionLevel EInterruptionLevel) *Payload {
+	p.aps().InterruptionLevel = interruptionLevel
 	return p
 }
 

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -346,7 +346,7 @@ func (p *Payload) InterruptionLevelActive() *Payload {
 	return p
 }
 
-// InterruptionLevelTimeSensitive sets the aps interruption-level to "time-senstive" on the payload.
+// InterruptionLevelTimeSensitive sets the aps interruption-level to "time-sensitive" on the payload.
 // This is to indicate the importance and delivery timing of a notification.
 // See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
 //

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -193,3 +193,33 @@ func TestCombined(t *testing.T) {
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"sound":"Default.caf"},"key":"val"}`, string(b))
 }
+
+func TestInterruptionLevelPassive(t *testing.T) {
+	payload := NewPayload().InterruptionLevelTimeSensitive().InterruptionLevelPassive()
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"interruption-level":"passive"}}`, string(b))
+}
+
+func TestInterruptionLevelActive(t *testing.T) {
+	payload := NewPayload().InterruptionLevelActive()
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"interruption-level":"active"}}`, string(b))
+}
+
+func TestInterruptionLevelTimeSensitive(t *testing.T) {
+	payload := NewPayload().InterruptionLevelTimeSensitive()
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"interruption-level":"time-sensitive"}}`, string(b))
+}
+
+func TestInterruptionLevelCritical(t *testing.T) {
+	payload := NewPayload().InterruptionLevelCritical()
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"interruption-level":"critical"}}`, string(b))
+}
+
+func TestRelevanceScore(t *testing.T) {
+	payload := NewPayload().RelevanceScore(0.1)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"relevance-score":0.1}}`, string(b))
+}

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -188,32 +188,26 @@ func TestAlertSummaryArgCount(t *testing.T) {
 	assert.Equal(t, `{"aps":{"alert":{"summary-arg-count":3}}}`, string(b))
 }
 
-func TestCombined(t *testing.T) {
-	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").Custom("key", "val")
-	b, _ := json.Marshal(payload)
-	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"sound":"Default.caf"},"key":"val"}`, string(b))
-}
-
 func TestInterruptionLevelPassive(t *testing.T) {
-	payload := NewPayload().InterruptionLevelTimeSensitive().InterruptionLevelPassive()
+	payload := NewPayload().InterruptionLevel(InterruptionLevelPassive)
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"interruption-level":"passive"}}`, string(b))
 }
 
 func TestInterruptionLevelActive(t *testing.T) {
-	payload := NewPayload().InterruptionLevelActive()
+	payload := NewPayload().InterruptionLevel(InterruptionLevelActive)
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"interruption-level":"active"}}`, string(b))
 }
 
 func TestInterruptionLevelTimeSensitive(t *testing.T) {
-	payload := NewPayload().InterruptionLevelTimeSensitive()
+	payload := NewPayload().InterruptionLevel(InterruptionLevelTimeSensitive)
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"interruption-level":"time-sensitive"}}`, string(b))
 }
 
 func TestInterruptionLevelCritical(t *testing.T) {
-	payload := NewPayload().InterruptionLevelCritical()
+	payload := NewPayload().InterruptionLevel(InterruptionLevelCritical)
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{"interruption-level":"critical"}}`, string(b))
 }
@@ -234,4 +228,10 @@ func TestUnsetRelevanceScore(t *testing.T) {
 	payload := NewPayload().RelevanceScore(0.1).UnsetRelevanceScore()
 	b, _ := json.Marshal(payload)
 	assert.Equal(t, `{"aps":{}}`, string(b))
+}
+
+func TestCombined(t *testing.T) {
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Custom("key", "val")
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf"},"key":"val"}`, string(b))
 }


### PR DESCRIPTION
- Adds interruption-level to payload
 interruption-level options:
    - passive
    - active (default if none is passed to apns)
    - time-sensitive
    - critical (requires Apple entitlement)
    
- Adds relevance-score to payload
- Updates readme re iOS 15 features
