### PR TITLE
Add location push type

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ APNS/2 is a go package designed for simple, flexible and fast Apple Push Notific
 - Works with go 1.7 and later
 - Supports new Apple Token Based Authentication (JWT)
 - Supports new iOS 10 features such as Collapse IDs, Subtitles and Mutable Notifications
-- Supports new iOS 15 fetaures interruptionLevel and relevanceScore
+- Supports new iOS 15 features interruptionLevel and relevanceScore
 - Supports persistent connections to APNs
 - Supports VoIP/PushKit notifications (iOS 8 and later)
 - Modular & easy to use

--- a/client_test.go
+++ b/client_test.go
@@ -252,6 +252,17 @@ func TestPushTypeBackgroundHeader(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPushTypeLocationHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeLocation
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "location", r.Header.Get("apns-push-type"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
 func TestPushTypeVOIPHeader(t *testing.T) {
 	n := mockNotification()
 	n.PushType = apns.PushTypeVOIP

--- a/notification.go
+++ b/notification.go
@@ -11,41 +11,52 @@ type EPushType string
 const (
 	// PushTypeAlert is used for notifications that trigger a user interaction —
 	// for example, an alert, badge, or sound. If you set this push type, the
-	// apns-topic header field must use your app’s bundle ID as the topic. The
-	// alert push type is required on watchOS 6 and later. It is recommended on
-	// macOS, iOS, tvOS, and iPadOS.
+	// topic field must use your app’s bundle ID as the topic. If the
+	// notification requires immediate action from the user, set notification
+	// priority to 10; otherwise use 5. The alert push type is required on
+	// watchOS 6 and later. It is recommended on macOS, iOS, tvOS, and iPadOS.
 	PushTypeAlert EPushType = "alert"
 
 	// PushTypeBackground is used for notifications that deliver content in the
 	// background, and don’t trigger any user interactions. If you set this push
-	// type, the apns-topic header field must use your app’s bundle ID as the
-	// topic. The background push type is required on watchOS 6 and later. It is
-	// recommended on macOS, iOS, tvOS, and iPadOS.
+	// type, the topic field must use your app’s bundle ID as the topic. Always
+	// use priority 5. Using priority 10 is an error. The background push type
+	// is required on watchOS 6 and later. It is recommended on macOS, iOS,
+	// tvOS, and iPadOS.
 	PushTypeBackground EPushType = "background"
 
+	// PushTypeLocation is used for notifications that request a user’s
+	// location. If you set this push type, the topic field must use your app’s
+	// bundle ID with .location-query appended to the end. The location push
+	// type is recommended for iOS and iPadOS. It isn’t available on macOS,
+	// tvOS, and watchOS. If the location query requires an immediate response
+	// from the Location Push Service Extension, set notification apns-priority
+	// to 10; otherwise, use 5. The location push type supports only token-based
+	// authentication.
+	PushTypeLocation EPushType = "location"
+
 	// PushTypeVOIP is used for notifications that provide information about an
-	// incoming Voice-over-IP (VoIP) call. If you set this push type, the
-	// apns-topic header field must use your app’s bundle ID with .voip appended
-	// to the end. If you’re using certificate-based authentication, you must
-	// also register the certificate for VoIP services. The voip push type is
-	// not available on watchOS. It is recommended on macOS, iOS, tvOS, and
-	// iPadOS.
+	// incoming Voice-over-IP (VoIP) call. If you set this push type, the topic
+	// field must use your app’s bundle ID with .voip appended to the end. If
+	// you’re using certificate-based authentication, you must also register the
+	// certificate for VoIP services. The voip push type is not available on
+	// watchOS. It is recommended on macOS, iOS, tvOS, and iPadOS.
 	PushTypeVOIP EPushType = "voip"
 
 	// PushTypeComplication is used for notifications that contain update
 	// information for a watchOS app’s complications. If you set this push type,
-	// the apns-topic header field must use your app’s bundle ID with
-	// .complication appended to the end. If you’re using certificate-based
-	// authentication, you must also register the certificate for WatchKit
-	// services. The complication push type is recommended for watchOS and iOS.
-	// It is not available on macOS, tvOS, and iPadOS.
+	// the topic field must use your app’s bundle ID with .complication appended
+	// to the end. If you’re using certificate-based authentication, you must
+	// also register the certificate for WatchKit services. The complication
+	// push type is recommended for watchOS and iOS. It is not available on
+	// macOS, tvOS, and iPadOS.
 	PushTypeComplication EPushType = "complication"
 
 	// PushTypeFileProvider is used to signal changes to a File Provider
-	// extension. If you set this push type, the apns-topic header field must
-	// use your app’s bundle ID with .pushkit.fileprovider appended to the end.
-	// The fileprovider push type is not available on watchOS. It is recommended
-	// on macOS, iOS, tvOS, and iPadOS.
+	// extension. If you set this push type, the topic field must use your app’s
+	// bundle ID with .pushkit.fileprovider appended to the end. The
+	// fileprovider push type is not available on watchOS. It is recommended on
+	// macOS, iOS, tvOS, and iPadOS.
 	PushTypeFileProvider EPushType = "fileprovider"
 
 	// PushTypeMDM is used for notifications that tell managed devices to

--- a/response.go
+++ b/response.go
@@ -9,8 +9,8 @@ import (
 // StatusSent is a 200 response.
 const StatusSent = http.StatusOK
 
-// The possible Reason error codes returned from APNs.
-// From table 8-6 in the Apple Local and Remote Notification Programming Guide.
+// The possible Reason error codes returned from APNs. From table 4 in the
+// Handling Notification Responses from APNs article
 const (
 	// 400 The collapse identifier exceeds the maximum allowed size
 	ReasonBadCollapseID = "BadCollapseId"
@@ -39,6 +39,9 @@ const (
 
 	// 400 Idle time out.
 	ReasonIdleTimeout = "IdleTimeout"
+
+	// 400 The apns-push-type value is invalid.
+	ReasonInvalidPushType = "InvalidPushType"
 
 	// 400 The device token is not specified in the request :path. Verify that the
 	// :path header contains the device token.


### PR DESCRIPTION
- Add support for [location push type](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns/) for [location push service extensions](https://developer.apple.com/documentation/corelocation/cllocationmanager/creating_a_location_push_service_extension) 
- Add InvalidPushType reason error code