### PR TITLE
Fix double pointer in Decode call

### DIFF
--- a/client.go
+++ b/client.go
@@ -184,7 +184,7 @@ func (c *Client) PushWithContext(ctx Context, n *Notification) (*Response, error
 	response.ApnsID = httpRes.Header.Get("apns-id")
 
 	decoder := json.NewDecoder(httpRes.Body)
-	if err := decoder.Decode(&response); err != nil && err != io.EOF {
+	if err := decoder.Decode(response); err != nil && err != io.EOF {
 		return &Response{}, err
 	}
 	return response, nil


### PR DESCRIPTION
Pointer to pointer passed to json Decode instead of plain pointer to struct. Standard JSON library pretty smart aware of it, but it results in unneeded allocation of reflect.Type/Kind highly likely internally in encoding/json.