### PR TITLE
Do not allocate empty response in case of error

### DIFF
--- a/response.go
+++ b/response.go
@@ -137,6 +137,9 @@ type Response struct {
 // Sent returns whether or not the notification was successfully sent.
 // This is the same as checking if the StatusCode == 200.
 func (c *Response) Sent() bool {
+	if c == nil {
+		return false
+	}
 	return c.StatusCode == StatusSent
 }
 


### PR DESCRIPTION
Doc string states that it's return response in case of success or an error in case of error