### PR TITLE
Utilised json.Unmarshal instead of json.NewDecoder

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -421,6 +421,17 @@ func TestMalformedJSONResponse(t *testing.T) {
 	assert.Equal(t, false, res.Sent())
 }
 
+func TestUnexpectedEOF(t *testing.T) {
+	n := mockNotification()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1")
+	}))
+	defer server.Close()
+	res, err := mockClient(server.URL).Push(n)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+}
+
 func TestCloseIdleConnections(t *testing.T) {
 	transport := &mockTransport{}
 


### PR DESCRIPTION
Truth be told, json decoder allocates more, it allocates decoder itself and also have logic/buffers related to stream processing which results in slower single JSON record decoding speed. Also reusing responses might be efficient since all responses quite equal in size here.