### PR TITLE
Add function to use alternative port (2197)

### DIFF
--- a/apns2/main.go
+++ b/apns2/main.go
@@ -16,6 +16,7 @@ var (
 	certificatePath = kingpin.Flag("certificate-path", "Path to certificate file.").Required().Short('c').String()
 	topic           = kingpin.Flag("topic", "The topic of the remote notification, which is typically the bundle ID for your app").Required().Short('t').String()
 	mode            = kingpin.Flag("mode", "APNS server to send notifications to. `production` or `development`. Defaults to `production`").Default("production").Short('m').String()
+	useAltPort      = kingpin.Flag("alt-port", "Use APNS's alternative port (2197). Default is port 443.").Default("false").Bool()
 )
 
 func main() {
@@ -37,6 +38,10 @@ func main() {
 		client.Development()
 	} else {
 		client.Production()
+	}
+
+	if *useAltPort {
+		client.UseAlternativePort()
 	}
 
 	scanner := bufio.NewScanner(os.Stdin)

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -142,6 +143,12 @@ func (c *Client) Development() *Client {
 // Production sets the Client to use the APNs production push endpoint.
 func (c *Client) Production() *Client {
 	c.Host = HostProduction
+	return c
+}
+
+// UseAlternativePort sets the Client to use APNs alternative endpoint port (2197).
+func (c *Client) UseAlternativePort() *Client {
+	c.Host = fmt.Sprintf("%s:2197", c.Host)
 	return c
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -63,9 +63,19 @@ func TestClientDefaultHost(t *testing.T) {
 	assert.Equal(t, "https://api.sandbox.push.apple.com", client.Host)
 }
 
+func TestClientDefaultHostWithAlternativePort(t *testing.T) {
+	client := apns.NewClient(mockCert()).UseAlternativePort()
+	assert.Equal(t, "https://api.sandbox.push.apple.com:2197", client.Host)
+}
+
 func TestTokenDefaultHost(t *testing.T) {
 	client := apns.NewTokenClient(mockToken()).Development()
 	assert.Equal(t, "https://api.sandbox.push.apple.com", client.Host)
+}
+
+func TestTokenDefaultHostWithAlternativePort(t *testing.T) {
+	client := apns.NewTokenClient(mockToken()).Development().UseAlternativePort()
+	assert.Equal(t, "https://api.sandbox.push.apple.com:2197", client.Host)
 }
 
 func TestClientDevelopmentHost(t *testing.T) {
@@ -73,9 +83,19 @@ func TestClientDevelopmentHost(t *testing.T) {
 	assert.Equal(t, "https://api.sandbox.push.apple.com", client.Host)
 }
 
+func TestClientDevelopmentHostWithAlternativePort(t *testing.T) {
+	client := apns.NewClient(mockCert()).Development().UseAlternativePort()
+	assert.Equal(t, "https://api.sandbox.push.apple.com:2197", client.Host)
+}
+
 func TestTokenClientDevelopmentHost(t *testing.T) {
 	client := apns.NewTokenClient(mockToken()).Development()
 	assert.Equal(t, "https://api.sandbox.push.apple.com", client.Host)
+}
+
+func TestTokenClientDevelopmentHostWithAlternativePort(t *testing.T) {
+	client := apns.NewTokenClient(mockToken()).Development().UseAlternativePort()
+	assert.Equal(t, "https://api.sandbox.push.apple.com:2197", client.Host)
 }
 
 func TestClientProductionHost(t *testing.T) {
@@ -83,9 +103,19 @@ func TestClientProductionHost(t *testing.T) {
 	assert.Equal(t, "https://api.push.apple.com", client.Host)
 }
 
+func TestClientProductionHostWithAlternativePort(t *testing.T) {
+	client := apns.NewClient(mockCert()).Production().UseAlternativePort()
+	assert.Equal(t, "https://api.push.apple.com:2197", client.Host)
+}
+
 func TestTokenClientProductionHost(t *testing.T) {
 	client := apns.NewTokenClient(mockToken()).Production()
 	assert.Equal(t, "https://api.push.apple.com", client.Host)
+}
+
+func TestTokenClientProductionHostWithAlternativePort(t *testing.T) {
+	client := apns.NewTokenClient(mockToken()).Production().UseAlternativePort()
+	assert.Equal(t, "https://api.push.apple.com:2197", client.Host)
 }
 
 func TestClientBadUrlError(t *testing.T) {


### PR DESCRIPTION
Apple allows you to use port 2197 instead of 443 when sending notifications to APNs. This PR implements a function that appends ":2197" to the client's host.

Note: If you are specifying production or development, then this function should be called after that.
Example: ` client := apns2.NewTokenClient(token).Development().UseAlternativePort()`

I also added the option --alt-port to the CLI client.

For more info you can take a look at [Sending Notification Requests to APNs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns/) in Apple's Developer Documentation