### PR TITLE
Add Live Activity type to EPushType

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -322,6 +322,17 @@ func TestPushTypeMDMHeader(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPushTypeLiveActivityHeader(t *testing.T) {
+	n := mockNotification()
+	n.PushType = apns.PushTypeLiveActivity
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "liveactivity", r.Header.Get("apns-push-type"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
 func TestAuthorizationHeader(t *testing.T) {
 	n := mockNotification()
 	token := mockToken()

--- a/notification.go
+++ b/notification.go
@@ -63,6 +63,14 @@ const (
 	// contact the MDM server. If you set this push type, you must use the topic
 	// from the UID attribute in the subject of your MDM push certificate.
 	PushTypeMDM EPushType = "mdm"
+
+	// PushTypeLiveActivity is used for Live Activities that display various
+	//	real-time information. If you set this push type, the topic field must
+	//	use your app’s bundle ID with push-type.liveactivity appended to the end.
+	//	The live activity push supports only token-based authentication. This
+	//	push type is recommended for iOS. It is not available on macOS, tvOS,
+	//	watchOS and iPadOS.
+	PushTypeLiveActivity EPushType = "liveactivity"
 )
 
 const (


### PR DESCRIPTION
Live Activities is a new feature in iOS 16 that helps users stay on top of things that are happening in real-time. This library can be used to trigger them and it just needs new const for convenience.