### PR TITLE
Fixes #220 - added ReasonExpiredToken.

### DIFF
--- a/response.go
+++ b/response.go
@@ -83,6 +83,9 @@ const (
 
 	// 405 The specified :method was not POST.
 	ReasonMethodNotAllowed = "MethodNotAllowed"
+	
+	/// 410 The device token has expired.
+	ReasonExpiredToken = "ExpiredToken"
 
 	// 410 The device token is inactive for the specified topic.
 	ReasonUnregistered = "Unregistered"


### PR DESCRIPTION
Fixes #220 

The `ExpiredToken` reason [is documented here](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns#3394529) but was not included with the other reasons.